### PR TITLE
Restored the no-explicit-any lint rule.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,6 @@
   "rules": {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-empty-interface": "off",
-    "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unused-vars": "warn",

--- a/resources/js/components/ui/Table/SortMarker.tsx
+++ b/resources/js/components/ui/Table/SortMarker.tsx
@@ -6,6 +6,7 @@ import {Dynamic} from "solid-js/web";
 import {css} from "..";
 
 interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   column: Column<any>;
 }
 

--- a/resources/js/components/ui/Table/TableContext.tsx
+++ b/resources/js/components/ui/Table/TableContext.tsx
@@ -3,6 +3,7 @@ import {createContext, ParentComponent, useContext} from "solid-js";
 
 type ProviderProps = {
   /** The table specified for the provider. Must not change. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   table: Table<any>;
 };
 

--- a/resources/js/features/root/pages/users_fake_tquery.ts
+++ b/resources/js/features/root/pages/users_fake_tquery.ts
@@ -16,6 +16,7 @@ import {rest, setupWorker} from "msw";
 type Row = Partial<Record<string, unknown>>;
 
 type ComparableVal = number | string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type CompareTransform = (v: any) => ComparableVal;
 
 const str = (v: unknown) => (v ?? undefined) as string | undefined;


### PR DESCRIPTION
Added suppression in the three places where any is currently necessary.