### PR TITLE
FZ-79 Improvements in modal.

### DIFF
--- a/resources/js/components/ui/Modal/Modal.module.scss
+++ b/resources/js/components/ui/Modal/Modal.module.scss
@@ -1,6 +1,6 @@
 .modal {
   [data-part="backdrop"] {
-    @apply fixed inset-0 bg-black bg-opacity-50;
+    @apply fixed inset-0 bg-black bg-opacity-30;
   }
 
   [data-part="container"] {
@@ -19,6 +19,10 @@
       .closeButton {
         @apply absolute top-0 right-0 m-1;
       }
+
+      .body {
+        @apply overflow-x-auto overflow-y-clip;
+      }
     }
   }
 
@@ -27,9 +31,10 @@
     font-size: 1.3em;
   }
 
-  &.narrow {
-    [data-part="content"] {
-      width: 400px;
+  &.withCloseButton {
+    [data-part="title"] {
+      // Make room for the close button.
+      @apply pr-4;
     }
   }
 }

--- a/resources/js/components/ui/Modal/Modal.tsx
+++ b/resources/js/components/ui/Modal/Modal.tsx
@@ -2,20 +2,30 @@ import * as dialog from "@zag-js/dialog";
 import {normalizeProps, useMachine} from "@zag-js/solid";
 import {cx, useLangFunc} from "components/utils";
 import {VsClose} from "solid-icons/vs";
-import {ParentProps, Show, createMemo, createRenderEffect, createUniqueId} from "solid-js";
+import {Accessor, JSX, Show, createMemo, createRenderEffect, createUniqueId} from "solid-js";
 import {Portal} from "solid-js/web";
+import {ChildrenOrFunc, getChildrenElement} from "../children_func";
 import s from "./Modal.module.scss";
 
-interface BaseProps {
+interface BaseProps<T> {
   title?: string;
-  /** Width of the modal. If not specified, it adjusts to contents, with a reasonable minimum. */
-  width?: "narrow";
   /**
-   * Whether the modal is opened.
-   *
-   * The only way to close the modal is to set this to false, the modal never closes itself.
+   * Style of the modal, mostly for specifying the size. When absent, a reasonable minimum width is used.
    */
-  open: boolean;
+  style?: JSX.CSSProperties;
+  /**
+   * A value determining whether the modal is open. If truthy, the value is also available for the modal
+   * children in its function form.
+   *
+   * The only way to close the modal is to set this to a falsy value (the modal never closes itself).
+   */
+  open: T | undefined | false;
+  /**
+   * Children can be either a standard JSX element, or a function that is called with an accessor
+   * to the non-nullable value passed to open. This is similar to the function form of the Show component.
+   * see Modal doc for example.
+   */
+  children: ChildrenOrFunc<[Accessor<NonNullable<T>>]>;
   /**
    * Handler called when the user tries to escape from the modal, either by pressing the Escape key,
    * or by clicking outside. If these actions should close the modal, this handler needs to set the
@@ -23,6 +33,10 @@ interface BaseProps {
    */
   onEscape?: (reason: EscapeReason) => void;
 }
+
+export const MODAL_STYLE_PRESETS = {
+  narrow: {width: "400px"},
+} satisfies Partial<Record<string, JSX.CSSProperties>>;
 
 const ESCAPE_REASONS = ["escapeKey", "clickOutside"] as const;
 
@@ -32,7 +46,7 @@ type EscapeReason = (typeof ESCAPE_REASONS)[number];
  * Props of a modal without close reasons specified. It can close itself by any of the escape reasons,
  * but doesn't have a close button.
  */
-interface PropsNoCloseReason extends BaseProps {
+interface PropsNoCloseReason<T> extends BaseProps<T> {
   closeOn?: undefined;
   onClose?: undefined;
 }
@@ -43,7 +57,7 @@ interface PropsNoCloseReason extends BaseProps {
  * If close reasons are specified using closeOn prop, the onClose handler needs to be specified as well,
  * to actually handle the closing.
  */
-interface PropsWithCloseReason<C extends CloseReason = CloseReason> extends BaseProps {
+interface PropsWithCloseReason<T, C extends CloseReason = CloseReason> extends BaseProps<T> {
   /**
    * The list of reasons that cause the modal to close.
    *
@@ -67,9 +81,9 @@ function isEscapeReason(reason: CloseReason): reason is EscapeReason {
   return (ESCAPE_REASONS as readonly CloseReason[]).includes(reason);
 }
 
-type Props<C extends CloseReason> = PropsNoCloseReason | PropsWithCloseReason<C>;
+type Props<T, C extends CloseReason> = PropsNoCloseReason<T> | PropsWithCloseReason<T, C>;
 
-export const Modal = <C extends CloseReason>(props: ParentProps<Props<C>>) => {
+export const Modal = <T, C extends CloseReason>(props: Props<T, C>) => {
   const t = useLangFunc();
   const closeOn = createMemo(
     () =>
@@ -102,33 +116,36 @@ export const Modal = <C extends CloseReason>(props: ParentProps<Props<C>>) => {
       api().close();
     }
   });
-  const modalWidthClass = () => (props.width === "narrow" ? s.narrow : undefined);
   return (
-    <Show when={api().isOpen}>
-      <Portal>
-        <div class={cx(s.modal, modalWidthClass())}>
-          <div {...api().backdropProps} />
-          <div {...api().containerProps}>
-            <div {...api().contentProps}>
-              <div class={s.innerContent}>
-                <Show when={closeOn().has("closeButton")}>
-                  <button
-                    class={s.closeButton}
-                    aria-label={t("close")}
-                    onClick={() => props.onClose?.("closeButton" as C)}
-                  >
-                    <VsClose class="w-6 h-6" />
-                  </button>
-                </Show>
-                <Show when={props.title}>
-                  <h2 {...api().titleProps}>{props.title}</h2>
-                </Show>
-                <div>{props.children}</div>
+    <Show when={props.open}>
+      {(value) => (
+        <Show when={api().isOpen}>
+          <Portal>
+            <div class={cx(s.modal, closeOn().has("closeButton") && s.withCloseButton)}>
+              <div {...api().backdropProps} />
+              <div {...api().containerProps}>
+                <div {...api().contentProps} style={props.style}>
+                  <div class={s.innerContent}>
+                    <Show when={closeOn().has("closeButton")}>
+                      <button
+                        class={s.closeButton}
+                        aria-label={t("close")}
+                        onClick={() => props.onClose?.("closeButton" as C)}
+                      >
+                        <VsClose class="w-6 h-6" />
+                      </button>
+                    </Show>
+                    <Show when={props.title}>
+                      <h2 {...api().titleProps}>{props.title}</h2>
+                    </Show>
+                    <div class={s.body}>{getChildrenElement(props.children, value)}</div>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-      </Portal>
+          </Portal>
+        </Show>
+      )}
     </Show>
   );
 };

--- a/resources/js/components/ui/Modal/Modal.tsx
+++ b/resources/js/components/ui/Modal/Modal.tsx
@@ -83,6 +83,29 @@ function isEscapeReason(reason: CloseReason): reason is EscapeReason {
 
 type Props<T, C extends CloseReason> = PropsNoCloseReason<T> | PropsWithCloseReason<T, C>;
 
+/**
+ * A modal, displaying on top of the page.
+ *
+ * The modal is opened whenever `props.open` is truthy. The modal never closes itself. The ways of
+ * closing the modal are described in the docs for props.
+ *
+ * The content of the modal can be specified either directly as children, or in the function form,
+ * in which case the content has access to the (non-nullable) value of `props.open`. This mechanism
+ * is similar to the function form of the `<Show>` component.
+ *
+ * Example:
+ *
+ *     declare const value: Accessor<string | undefined>;
+ *
+ *     <Modal open={value()}>
+ *       {(value: Accessor<string>) => (
+ *         <>
+ *           <div>string: {value()}</div>
+ *           <div>length: {value().length}</div>
+ *         </>
+ *       )}
+ *     </Modal>
+ */
 export const Modal = <T, C extends CloseReason>(props: Props<T, C>) => {
   const t = useLangFunc();
   const closeOn = createMemo(

--- a/resources/js/components/ui/children_func.ts
+++ b/resources/js/components/ui/children_func.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Utilities for creating components that can take children in the function form,
+ * like Show does.
+ */
+
+import {JSX} from "solid-js";
+
+/** Parameters for the children function. There needs to be at least one parameter. */
+type ChildrenFuncParams = [unknown, ...unknown[]];
+
+/** A function that can be specified as props.children. */
+export type ChildrenFunc<P extends ChildrenFuncParams> = (...params: P) => JSX.Element;
+
+/**
+ * The type of props.children that can accept either an element directly, or a children function.
+ * Use getChildrenElement on props.children to retrieve the element or call the children function.
+ */
+export type ChildrenOrFunc<P extends ChildrenFuncParams> = JSX.Element | ChildrenFunc<P>;
+
+/**
+ * Returns the children elements based on props children (which can be elements or a children function)
+ * and arguments for the children fuction.
+ */
+export function getChildrenElement<P extends ChildrenFuncParams>(
+  propsChildren: ChildrenOrFunc<P>,
+  ...args: P
+): JSX.Element {
+  return isChildrenFunc(propsChildren) ? propsChildren(...args) : propsChildren;
+}
+
+export function isChildrenFunc<P extends ChildrenFuncParams>(children: ChildrenOrFunc<P>): children is ChildrenFunc<P> {
+  return typeof children === "function" && children.length > 0;
+}

--- a/resources/js/features/authentication/forms/login/Login.form.tsx
+++ b/resources/js/features/authentication/forms/login/Login.form.tsx
@@ -1,7 +1,7 @@
 import {FormConfigWithoutTransformFn} from "@felte/core";
 import {createMutation} from "@tanstack/solid-query";
 import {FelteForm, FelteSubmit} from "components/felte-form";
-import {FullLogo, Modal as ModalComponent, TextField} from "components/ui";
+import {FullLogo, MODAL_STYLE_PRESETS, Modal as ModalComponent, TextField} from "components/ui";
 import {User} from "data-access/memo-api";
 import {Component, createSignal} from "solid-js";
 import {z} from "zod";
@@ -63,7 +63,7 @@ export namespace LoginForm {
    * when showModal is called.
    */
   export const Modal: Component = () => (
-    <ModalComponent open={modalShown()} width="narrow">
+    <ModalComponent open={modalShown()} style={MODAL_STYLE_PRESETS.narrow}>
       <div class="flex flex-col gap-4">
         <div class="self-center">
           <FullLogo />

--- a/resources/js/features/user-panel/PasswordChange.form.tsx
+++ b/resources/js/features/user-panel/PasswordChange.form.tsx
@@ -1,12 +1,12 @@
 import {FormConfigWithoutTransformFn} from "@felte/core";
 import {createMutation, createQuery} from "@tanstack/solid-query";
 import {FelteForm, FelteSubmit} from "components/felte-form";
-import {Modal as ModalComponent, TextField} from "components/ui";
+import {MODAL_STYLE_PRESETS, Modal as ModalComponent, TextField} from "components/ui";
+import {useLangFunc} from "components/utils";
 import {User} from "data-access/memo-api";
 import {Component, createSignal} from "solid-js";
-import {z} from "zod";
-import {useLangFunc} from "components/utils";
 import toast from "solid-toast";
+import {z} from "zod";
 
 export namespace PasswordChangeForm {
   export const getSchema = () =>
@@ -88,7 +88,7 @@ export namespace PasswordChangeForm {
         open={modalShown()}
         closeOn={["escapeKey", "closeButton"]}
         onClose={() => setModalShown(false)}
-        width="narrow"
+        style={MODAL_STYLE_PRESETS.narrow}
       >
         <Component onSuccess={() => setModalShown(false)} />
       </ModalComponent>


### PR DESCRIPTION
- The props.open value can now be of any type and is available in the modal content (similar to how Show works).
- Modal style can now be passed in props.
- Improved styling around the close button.