### PR TITLE
FZ-39-tquery-table

### DIFF
--- a/resources/js/data-access/memo-api/groups/Admin.ts
+++ b/resources/js/data-access/memo-api/groups/Admin.ts
@@ -14,4 +14,9 @@ export namespace Admin {
 
   export const getUsers = () =>
     V1.get<Api.Response.GetList<AdminUserResource>>("/admin/user/list").then(parseGetListResponse);
+
+  export const keys = {
+    all: () => ["admin"] as const,
+    users: () => [...keys.all(), "users"] as const,
+  };
 }

--- a/resources/js/data-access/memo-api/groups/Admin.ts
+++ b/resources/js/data-access/memo-api/groups/Admin.ts
@@ -17,6 +17,7 @@ export namespace Admin {
 
   export const keys = {
     all: () => ["admin"] as const,
-    users: () => [...keys.all(), "users"] as const,
+    userAll: () => [...keys.all(), "user"] as const,
+    userLists: () => [...keys.userAll(), "list"] as const,
   };
 }

--- a/resources/js/features/root/pages/AdminUsersList.page.tsx
+++ b/resources/js/features/root/pages/AdminUsersList.page.tsx
@@ -1,10 +1,10 @@
+import {Row} from "@tanstack/solid-table";
 import {Email, Modal, css} from "components/ui";
 import {TQueryTable} from "components/ui/Table/TQueryTable";
 import {AccessBarrier, DATE_TIME_WITH_WEEKDAY_FORMAT} from "components/utils";
+import {Admin} from "data-access/memo-api/groups/Admin";
 import {BiSolidUserDetail} from "solid-icons/bi";
 import {Component, Show, createSignal} from "solid-js";
-
-import {Row} from "@tanstack/solid-table";
 import {startUsersMock} from "./users_fake_tquery";
 
 export default (() => {
@@ -14,8 +14,10 @@ export default (() => {
     <AccessBarrier roles={["globalAdmin"]}>
       <TQueryTable
         mode="standalone"
+        staticPrefixQueryKey={Admin.keys.users()}
         staticEntityURL="entityURL"
         translations="tables.tables.users"
+        intrinsicColumns={["id"]}
         additionalColumns={["actions"]}
         columnOptions={{
           id: {
@@ -55,7 +57,8 @@ export default (() => {
             metaParams: {canControlVisibility: false},
           },
         }}
-        initialVisibleColumns={["name", "createdAt", "actions"]}
+        initialColumnsOrder={["name", "email", "createdAt", "facilitiesMember", "numFacilities", "hasGlobalAdmin"]}
+        initialVisibleColumns={["name", "email", "createdAt", "facilitiesMember", "hasGlobalAdmin", "actions"]}
         initialSort={[{id: "name", desc: false}]}
       />
       <Modal

--- a/resources/js/features/root/pages/AdminUsersList.page.tsx
+++ b/resources/js/features/root/pages/AdminUsersList.page.tsx
@@ -14,7 +14,7 @@ export default (() => {
     <AccessBarrier roles={["globalAdmin"]}>
       <TQueryTable
         mode="standalone"
-        staticPrefixQueryKey={Admin.keys.users()}
+        staticPrefixQueryKey={Admin.keys.userLists()}
         staticEntityURL="entityURL"
         translations="tables.tables.users"
         intrinsicColumns={["id"]}

--- a/resources/js/features/root/pages/users_fake_tquery.ts
+++ b/resources/js/features/root/pages/users_fake_tquery.ts
@@ -106,13 +106,13 @@ export function startUsersMock() {
   }));
   const facilitiesQuery = createQuery(() => System.facilitiesQueryOptions);
   const columns: ColumnSchema[] = [
+    {name: "createdAt", type: "datetime"},
+    {name: "email", type: "string"},
+    {name: "facilitiesMember", type: "text"},
+    {name: "hasGlobalAdmin", type: "bool"},
     {name: "id", type: "string"},
     {name: "name", type: "string"},
-    {name: "email", type: "string"},
-    {name: "createdAt", type: "datetime"},
-    {name: "facilitiesMember", type: "text"},
     {name: "numFacilities", type: "decimal0"},
-    {name: "hasGlobalAdmin", type: "bool"},
   ];
   setupWorker(
     rest.get("/api/v1/entityURL/tquery", (req, res, ctx) => {


### PR DESCRIPTION
- The page can specify the order of columns in the table.
- Ability to specify columns that are fetched even if hidden (useful especially for id).
- Ability to specify the prefix for the TanStack query key of tquery data query to be able to invalidate globally. Removed invalidation functions from tquery.