### PR TITLE
Separated the tquery logic from the Table component.

### DIFF
--- a/resources/js/components/ui/CopyToClipboard.tsx
+++ b/resources/js/components/ui/CopyToClipboard.tsx
@@ -4,7 +4,7 @@ import {css} from ".";
 import {useLangFunc} from "../utils";
 
 interface Props {
-  text: string;
+  text: string | undefined;
 }
 
 /** A "Copy to clipboard" icon, copying the specified text on click. */
@@ -13,17 +13,19 @@ export const CopyToClipboard: Component<ParentProps<Props>> = (props) => {
   const [copied, setCopied] = createSignal(false);
   return (
     <Show when={props.text}>
-      <button title={t("copy_to_clipboard")}>
-        <BiRegularCopy
-          class={css.inlineIcon}
-          classList={{"text-black": true, "text-opacity-30": !copied()}}
-          onClick={() => {
-            navigator.clipboard.writeText(props.text);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 350);
-          }}
-        />
-      </button>
+      {(text) => (
+        <button title={t("copy_to_clipboard")}>
+          <BiRegularCopy
+            class={css.inlineIcon}
+            classList={{"text-black": true, "text-opacity-30": !copied()}}
+            onClick={() => {
+              navigator.clipboard.writeText(text());
+              setCopied(true);
+              setTimeout(() => setCopied(false), 350);
+            }}
+          />
+        </button>
+      )}
     </Show>
   );
 };

--- a/resources/js/components/ui/Email.tsx
+++ b/resources/js/components/ui/Email.tsx
@@ -1,13 +1,14 @@
-import {Component} from "solid-js";
+import {Component, Show} from "solid-js";
 import {CopyToClipboard} from "./CopyToClipboard";
+import {EMPTY_VALUE_SYMBOL} from "./symbols";
 
 interface Props {
-  email: string;
+  email: string | undefined;
 }
 
 /** A component for displaying a copiable email address. No mailto. */
 export const Email: Component<Props> = (props) => (
-  <span>
+  <Show when={props.email} fallback={EMPTY_VALUE_SYMBOL}>
     {props.email} <CopyToClipboard text={props.email} />
-  </span>
+  </Show>
 );

--- a/resources/js/components/ui/Table/ColumnName.tsx
+++ b/resources/js/components/ui/Table/ColumnName.tsx
@@ -1,0 +1,32 @@
+import {ColumnDef} from "@tanstack/solid-table";
+import {Component, Show} from "solid-js";
+import {Capitalize} from "../Capitalize";
+import {useTable} from "./TableContext";
+
+interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  def: ColumnDef<any>;
+}
+
+/**
+ * Component displaying the column name, taken from column meta.columnName if present,
+ * otherwise from table meta.translations, or finally from the column id.
+ */
+export const ColumnName: Component<Props> = (props) => {
+  const table = useTable();
+  return (
+    <Show
+      when={props.def.meta?.columnName}
+      fallback={
+        <Show
+          when={table.options.meta?.translations?.headers?.(props.def.id || "", {defaultValue: ""})}
+          fallback={props.def.id}
+        >
+          {(columnName) => <Capitalize text={columnName()} />}
+        </Show>
+      }
+    >
+      {(columnName) => <>{columnName()()}</>}
+    </Show>
+  );
+};

--- a/resources/js/components/ui/Table/Header.tsx
+++ b/resources/js/components/ui/Table/Header.tsx
@@ -1,0 +1,46 @@
+import {HeaderContext} from "@tanstack/solid-table";
+import {useLangFunc} from "components/utils";
+import {Component, JSX, Show, createMemo} from "solid-js";
+import {ColumnName, SortMarker, tableStyle as ts} from ".";
+
+interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ctx: HeaderContext<any, unknown>;
+  filter?: JSX.Element;
+}
+
+/**
+ * Component displaying the header of a table column. Supports sorting and resizing,
+ * as well as filtering if filter element is provided.
+ */
+export const Header: Component<Props> = (props) => {
+  const t = useLangFunc();
+  const resizeHandler = createMemo(() => props.ctx.header.getResizeHandler());
+  return (
+    <div class={ts.headerCell}>
+      <span
+        class={ts.title}
+        classList={{"cursor-pointer": props.ctx.column.getCanSort()}}
+        onClick={(e) => {
+          e.preventDefault();
+          if (props.ctx.column.getCanSort()) {
+            props.ctx.column.toggleSorting(undefined, e.altKey);
+          }
+        }}
+        title={props.ctx.column.getCanSort() ? t("tables.sort_tooltip") : undefined}
+      >
+        <ColumnName def={props.ctx.column.columnDef} />
+        <SortMarker column={props.ctx.column} />
+      </span>
+      <Show when={props.ctx.column.getCanFilter()}>{props.filter}</Show>
+      <Show when={props.ctx.column.getCanResize()}>
+        <div
+          class={ts.resizeHandler}
+          classList={{[ts.resizing!]: props.ctx.column.getIsResizing()}}
+          onMouseDown={(e) => resizeHandler()(e)}
+          onTouchStart={(e) => resizeHandler()(e)}
+        />
+      </Show>
+    </div>
+  );
+};

--- a/resources/js/components/ui/Table/Header.tsx
+++ b/resources/js/components/ui/Table/Header.tsx
@@ -18,19 +18,13 @@ export const Header: Component<Props> = (props) => {
   const resizeHandler = createMemo(() => props.ctx.header.getResizeHandler());
   return (
     <div class={ts.headerCell}>
-      <span
-        class={ts.title}
-        classList={{"cursor-pointer": props.ctx.column.getCanSort()}}
-        onClick={(e) => {
-          e.preventDefault();
-          if (props.ctx.column.getCanSort()) {
-            props.ctx.column.toggleSorting(undefined, e.altKey);
-          }
-        }}
-        title={props.ctx.column.getCanSort() ? t("tables.sort_tooltip") : undefined}
-      >
-        <ColumnName def={props.ctx.column.columnDef} />
-        <SortMarker column={props.ctx.column} />
+      <span class={ts.title}>
+        <Show when={props.ctx.column.getCanSort()} fallback={<ColumnName def={props.ctx.column.columnDef} />}>
+          <button onClick={(e) => props.ctx.column.toggleSorting(undefined, e.altKey)} title={t("tables.sort_tooltip")}>
+            <ColumnName def={props.ctx.column.columnDef} />
+            <SortMarker column={props.ctx.column} />
+          </button>
+        </Show>
       </span>
       <Show when={props.ctx.column.getCanFilter()}>{props.filter}</Show>
       <Show when={props.ctx.column.getCanResize()}>

--- a/resources/js/components/ui/Table/Table.module.scss
+++ b/resources/js/components/ui/Table/Table.module.scss
@@ -98,17 +98,37 @@
   @apply w-auto flex items-center;
 }
 
+.headerCell {
+  @apply h-full w-full flex flex-col items-stretch gap-0.5 justify-between;
+  // Create a positioned ancestor for the resize handler.
+  @apply relative;
+  @apply px-2 py-1;
+
+  .title {
+    @apply font-bold;
+  }
+
+  .resizeHandler {
+    @apply absolute top-0 right-0 h-full cursor-col-resize;
+    width: 5px;
+    @apply select-none touch-none;
+
+    &:hover {
+      @apply bg-gray-400;
+    }
+
+    &.resizing {
+      @apply bg-blue-700;
+    }
+  }
+}
+
 .tableContainer {
   @apply flex flex-col gap-1;
 
-  .aboveTable {
-    @apply bg-white;
-    @apply h-8 flex items-stretch gap-1;
-  }
-
+  .aboveTable,
   .belowTable {
     @apply bg-white;
-    @apply h-8 flex items-stretch gap-2;
   }
 
   .tableBg {
@@ -125,27 +145,7 @@
 
         .cell {
           @apply outline outline-1 outline-gray-400 bg-gray-100;
-          @apply flex flex-col items-stretch gap-0.5 justify-between;
-          // Create a positioned ancestor for the resize handler.
-          @apply relative;
-
-          .title {
-            @apply font-bold;
-          }
-
-          .resizeHandler {
-            @apply absolute top-0 right-0 h-full cursor-col-resize;
-            width: 5px;
-            @apply select-none touch-none;
-
-            &:hover {
-              @apply bg-gray-400;
-            }
-
-            &.resizing {
-              @apply bg-blue-700;
-            }
-          }
+          min-height: 30px;
         }
       }
 
@@ -154,16 +154,13 @@
 
         .cell {
           @apply bg-white text-black whitespace-pre-wrap;
+          @apply px-2 py-1 flex items-center overflow-x-hidden;
+          min-height: 30px;
         }
 
         &:hover .cell {
           @apply bg-gray-50;
         }
-      }
-
-      .cell {
-        @apply px-2 py-1 flex items-center overflow-x-hidden;
-        min-height: 30px;
       }
 
       .wideRow {
@@ -198,10 +195,12 @@
       .headerRow .cell {
         @apply sticky;
         // Just below the sticky aboveTable bar.
-        top: 33px;
+        top: calc(var(--aboveTableHeight) + 1px);
       }
       .bottomBorder {
-        @apply sticky bottom-8;
+        @apply sticky;
+        // Just below the sticky belowTable bar.
+        bottom: var(--belowTableHeight);
       }
     }
   }

--- a/resources/js/components/ui/Table/Table.tsx
+++ b/resources/js/components/ui/Table/Table.tsx
@@ -1,0 +1,272 @@
+import {
+  PaginationState,
+  RowData,
+  SortingState,
+  TableOptions,
+  Table as TanStackTable,
+  VisibilityState,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+} from "@tanstack/solid-table";
+import {LangEntryFunc, LangPrefixFunc, createTranslationsFromPrefix, cx} from "components/utils";
+import {Accessor, For, Index, JSX, Show, Signal, createEffect, createSignal, mergeProps, on} from "solid-js";
+import {TableContextProvider, getHeaders, tableStyle as ts, useTableCells} from ".";
+import {EMPTY_VALUE_SYMBOL, Spinner} from "..";
+import {CellRenderer} from "./CellRenderer";
+
+export interface TableTranslations {
+  /** Entries for the table column names. */
+  headers: LangPrefixFunc;
+  /** Summary of the table, taking the number of rows as count. */
+  summary: LangEntryFunc;
+}
+
+export function createTableTranslations(tableName: string): TableTranslations {
+  return createTranslationsFromPrefix(`tables.tables.${tableName}`, ["headers", "summary"]);
+}
+
+declare module "@tanstack/table-core" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface TableMeta<TData extends RowData> {
+    /** The translations for the table, used by various table-related components. */
+    translations?: TableTranslations;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    /**
+     * The simple representation of the translated column name. If set, overrides the value from
+     * table meta translations.
+     */
+    columnName?: () => JSX.Element;
+  }
+}
+
+/**
+ * Mode in which the table is displayed:
+ * - standalone - the table is the main element on the page, typically displays many rows,
+ * header and footer are sticky.
+ * - embedded - the table is displayed along with other elements in a page, typically with not
+ * many rows, without sticky elements.
+ */
+export type DisplayMode = "standalone" | "embedded";
+
+interface Props<T = object> {
+  table: TanStackTable<T>;
+  /** Table mode. Default: embedded. */
+  mode?: DisplayMode;
+  /** Whether the column sizes are taken from the content size. Default: true. */
+  autoColumnSize?: boolean;
+  /** The content to put above the table, e.g. the global search bar. */
+  aboveTable?: () => JSX.Element;
+  /**
+   * The height of the aboveTable element. It is important to calculate the sticky header position
+   * in the standalone mode. Default: 32.
+   */
+  aboveTableHeight?: number;
+  /** The content to put below the table, e.g. the pagination controller. */
+  belowTable?: () => JSX.Element;
+  /**
+   * The height of the belowTable element. It is important to calculate the sticky lower bar position
+   * in the standalone mode. Default: 32.
+   */
+  belowTableHeight?: number;
+  /** Whether the whole table content is loading. This hides the whole table and displays a spinner. */
+  isLoading?: boolean;
+  /** Whether the content of the table is reloading. This dims the table and makes it inert. */
+  isDimmed?: boolean;
+  /** A signal which changes when the table should scroll itself to the top. */
+  scrollToTopSignal?: Accessor<unknown>;
+}
+
+const DEFAULT_PROPS = {
+  mode: "embedded",
+  autoColumnSize: true,
+  aboveTableHeight: 32,
+  belowTableHeight: 32,
+  isLoading: false,
+  isDimmed: false,
+} satisfies Partial<Props>;
+
+/** A typical list of classes for the aboveTable and belowTable elements. */
+export const ABOVE_AND_BELOW_TABLE_DEFAULT_CSS = "h-full flex items-stretch";
+
+/**
+ * A table. Most aspects of the table are controlled by props.table, some additional options
+ * are controlled via other props.
+ *
+ * Limitations:
+ * - no column groups
+ * - no foldable rows
+ */
+export const Table = <T,>(optProps: Props<T>) => {
+  const props = mergeProps(DEFAULT_PROPS, optProps);
+  let scrollToTopPoint: HTMLDivElement | undefined;
+  createEffect(
+    on(
+      () => props.scrollToTopSignal?.(),
+      () => scrollToTopPoint?.scrollIntoView({behavior: "smooth"}),
+    ),
+  );
+  const gridTemplateColumns = () =>
+    props.autoColumnSize
+      ? `repeat(${props.table.getVisibleLeafColumns().length}, auto)`
+      : props.table
+          .getVisibleLeafColumns()
+          .map((c) => `${c.getSize()}px`)
+          .join(" ");
+  return (
+    <TableContextProvider table={props.table}>
+      <Show when={!props.isLoading} fallback={<Spinner />}>
+        <div
+          ref={scrollToTopPoint}
+          class={cx(ts.tableContainer, props.mode === "standalone" ? ts.standalone : ts.embedded)}
+        >
+          <Show when={props.aboveTable}>
+            <div class={ts.aboveTable} style={{height: `${props.aboveTableHeight}px`}}>
+              {props.aboveTable?.()}
+            </div>
+          </Show>
+          <div class={ts.tableBg}>
+            <div
+              class={ts.table}
+              classList={{[ts.dimmed!]: props.isDimmed}}
+              style={{
+                "grid-template-columns": gridTemplateColumns(),
+              }}
+            >
+              <div
+                class={ts.headerRow}
+                style={{"--aboveTableHeight": `${props.aboveTable ? props.aboveTableHeight : 0}px`}}
+              >
+                <For each={getHeaders(props.table)}>
+                  {({header, column}) => (
+                    <Show when={header()}>
+                      {(header) => (
+                        <div class={ts.cell}>
+                          <Show when={!header().isPlaceholder}>
+                            <CellRenderer component={column.columnDef.header} props={header().getContext()} />
+                          </Show>
+                        </div>
+                      )}
+                    </Show>
+                  )}
+                </For>
+              </div>
+              <Index
+                each={props.table.getRowModel().rows}
+                fallback={
+                  <div class={ts.wideRow}>
+                    <Show when={props.isDimmed} fallback={EMPTY_VALUE_SYMBOL}>
+                      <Spinner />
+                    </Show>
+                  </div>
+                }
+              >
+                {(row) => (
+                  <div class={ts.dataRow} inert={props.isDimmed || undefined}>
+                    <Index each={row().getVisibleCells()}>
+                      {(cell) => (
+                        <span class={ts.cell}>
+                          <CellRenderer component={cell().column.columnDef.cell} props={cell().getContext()} />
+                        </span>
+                      )}
+                    </Index>
+                  </div>
+                )}
+              </Index>
+              <div
+                class={ts.bottomBorder}
+                style={{"--belowTableHeight": `${props.belowTable ? props.belowTableHeight : 0}px`}}
+              />
+            </div>
+          </div>
+          <Show when={props.belowTable}>
+            <div class={ts.belowTable} style={{height: `${props.belowTableHeight}px`}}>
+              {props.belowTable?.()}
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </TableContextProvider>
+  );
+};
+
+/**
+ * Features that the table should support.
+ *
+ * Each feature can be specified by providing an external signal, or initial value,
+ * or just true to use the defaults. Missing key or false disables the feature.
+ */
+export interface TableFeaturesConfig {
+  columnVisibility?: boolean | Signal<VisibilityState> | VisibilityState;
+  sorting?: boolean | Signal<SortingState> | SortingState;
+  globalFilter?: boolean | Signal<string> | string;
+  pagination?: boolean | Signal<PaginationState> | PaginationState;
+}
+
+const DEFAULT_PAGE_SIZE = 50;
+
+/** Returns base options for createSolidTable. */
+export function getBaseTableOptions<T>({
+  columnVisibility,
+  sorting,
+  globalFilter,
+  pagination,
+}: TableFeaturesConfig = {}) {
+  const tableCells = useTableCells();
+  const columnVisibilitySignal = getFeatureSignal(columnVisibility, {});
+  const sortingSignal = getFeatureSignal(sorting, []);
+  const globalFilterSignal = getFeatureSignal(globalFilter, "");
+  const paginationSignal = getFeatureSignal(pagination, {pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE});
+  return {
+    maxMultiSortColCount: 2,
+    enableSortingRemoval: false,
+    columnResizeMode: "onChange",
+    defaultColumn: {
+      header: tableCells.defaultHeader,
+      cell: tableCells.default,
+      minSize: 50,
+      size: 250,
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    state: {
+      get columnVisibility() {
+        return columnVisibilitySignal?.[0]();
+      },
+      get sorting() {
+        return sortingSignal?.[0]();
+      },
+      get globalFilter() {
+        return globalFilterSignal?.[0]();
+      },
+      get pagination() {
+        return paginationSignal?.[0]();
+      },
+    },
+    onColumnVisibilityChange: columnVisibilitySignal?.[1],
+    onSortingChange: sortingSignal?.[1],
+    onGlobalFilterChange: globalFilterSignal?.[1],
+    onPaginationChange: paginationSignal?.[1],
+  } satisfies Partial<TableOptions<T>>;
+}
+
+function getFeatureSignal<T>(feature: undefined | boolean | Signal<T> | T, defaultInitial: T): Signal<T> | undefined {
+  if (!feature) {
+    return undefined;
+  }
+  if (feature === true) {
+    const [get, set] = createSignal(defaultInitial);
+    return [get, set];
+  }
+  if (Array.isArray(feature) && feature.length === 2 && typeof feature[0] === "function") {
+    return feature;
+  }
+  const [get, set] = createSignal(feature as T);
+  return [get, set];
+}

--- a/resources/js/components/ui/Table/TableColumnVisibilityController.tsx
+++ b/resources/js/components/ui/Table/TableColumnVisibilityController.tsx
@@ -1,22 +1,10 @@
-import {RowData} from "@tanstack/solid-table";
 import * as popover from "@zag-js/popover";
 import {normalizeProps, useMachine} from "@zag-js/solid";
 import {useLangFunc} from "components/utils";
-import {Component, For, JSX, Show, createMemo, createUniqueId} from "solid-js";
+import {Component, For, Show, createMemo, createUniqueId} from "solid-js";
 import {Portal} from "solid-js/web";
-import {tableStyle as ts, useTable} from ".";
+import {ColumnName, tableStyle as ts, useTable} from ".";
 import {Button} from "../Button";
-
-declare module "@tanstack/table-core" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData extends RowData, TValue> {
-    /**
-     * The column name. Separating this value from the header property of column definition
-     * allows reusing the column visibility component across different types of tables.
-     */
-    columnName?: JSX.Element;
-  }
-}
 
 export const TableColumnVisibilityController: Component = () => {
   const t = useLangFunc();
@@ -52,7 +40,7 @@ export const TableColumnVisibilityController: Component = () => {
                         onChange={column.getToggleVisibilityHandler()}
                         type="checkbox"
                       />{" "}
-                      {column.columnDef.meta?.columnName || column.columnDef.id}
+                      <ColumnName def={column.columnDef} />
                     </label>
                   </Show>
                 )}

--- a/resources/js/components/ui/Table/TableSummary.tsx
+++ b/resources/js/components/ui/Table/TableSummary.tsx
@@ -1,21 +1,39 @@
-import {LangEntryFunc} from "components/utils";
-import {Component, createMemo, on} from "solid-js";
+import {LangEntryFunc, useLangFunc} from "components/utils";
+import {Component, Show} from "solid-js";
 import {tableStyle as ts, useTable} from ".";
 
 interface Props {
-  /** Number of rows. Must be specified for backend tables. */
+  /**
+   * Number of rows. Must be specified for backend tables where it cannot be taken from the
+   * table object.
+   */
   rowsCount?: number;
-  /** Translation entry for the plural summary, taking the number of rows. */
-  summaryTranslation: LangEntryFunc;
+  /**
+   * Translation entry for the plural summary, taking the number of rows. Defaults to the value from
+   * meta.translations in table, and then to a generic default.
+   */
+  summaryTranslation?: LangEntryFunc;
 }
 
 export const TableSummary: Component<Props> = (props) => {
+  const t = useLangFunc();
   const table = useTable();
-  const rowsCount = createMemo(
-    on(
-      [() => props.rowsCount, () => table.getRowModel().rows.length],
-      ([propsRowsCount, tableRowsCount]) => propsRowsCount ?? tableRowsCount,
-    ),
+  const count = () => props.rowsCount ?? table.getRowModel().rows.length;
+  return (
+    <div class={ts.tableSummary}>
+      <Show
+        when={props.summaryTranslation}
+        fallback={
+          <Show
+            when={table.options.meta?.translations?.summary?.({count: count(), defaultValue: ""})}
+            fallback={t("tables.tables.generic.summary", {count: count()})}
+          >
+            {(summary) => <>{summary()}</>}
+          </Show>
+        }
+      >
+        {(summaryTranslation) => <>{summaryTranslation()({count: count()})}</>}
+      </Show>
+    </div>
   );
-  return <div class={ts.tableSummary}>{props.summaryTranslation({count: rowsCount()})}</div>;
 };

--- a/resources/js/components/ui/Table/headers_iterator.ts
+++ b/resources/js/components/ui/Table/headers_iterator.ts
@@ -19,7 +19,7 @@ import {createMemo} from "solid-js";
  *       </Show>}
  *     </For>
  */
-export function getHeaders(table: Table<object>) {
+export function getHeaders<T>(table: Table<T>) {
   return table.getAllLeafColumns().map((column) => {
     const header = createMemo(() => table.getLeafHeaders().find((h) => h.id === column.id));
     return {header, column};

--- a/resources/js/components/ui/Table/index.ts
+++ b/resources/js/components/ui/Table/index.ts
@@ -1,9 +1,13 @@
+export * from "./ColumnName";
 export * from "./FilterIcon";
+export * from "./Header";
 export * from "./Pagination";
 export * from "./SortMarker";
+export * from "./Table";
+export {default as tableStyle} from "./Table.module.scss";
 export * from "./TableColumnVisibilityController";
 export * from "./TableContext";
 export * from "./TableSearch";
 export * from "./TableSummary";
 export * from "./headers_iterator";
-export {default as tableStyle} from "./style.module.scss";
+export * from "./table_cells";

--- a/resources/js/components/ui/Table/table_cells.tsx
+++ b/resources/js/components/ui/Table/table_cells.tsx
@@ -1,0 +1,41 @@
+import {CellContext, HeaderContext} from "@tanstack/solid-table";
+import {
+  DATE_FORMAT,
+  DATE_TIME_FORMAT,
+  DECIMAL0_NUMBER_FORMAT,
+  DECIMAL2_NUMBER_FORMAT,
+  useLangFunc,
+} from "components/utils";
+import {JSX, Show} from "solid-js";
+import {Header} from "./Header";
+
+/** The component used as header in column definition. */
+export type HeaderComponent = <T>(ctx: HeaderContext<T, unknown>) => JSX.Element;
+
+/**
+ * The component used as cell in column definition.
+ *
+ * Warning: It function must not return a string directly, it needs to be wrapped in a JSX.Element,
+ * e.g. `<>{someString}</>`. Otherwise the reactivity is lost and the cell will show stale data.
+ * It is not possible to express this requirement in the type.
+ */
+export type CellComponent = <T>(ctx: CellContext<T, unknown>) => JSX.Element;
+
+/** Returns a collection of cell functions for various data types. */
+export function useTableCells() {
+  const t = useLangFunc();
+  function cellFunc<V>(func: (v: V) => JSX.Element | undefined): CellComponent {
+    return (c) => <Show when={c.getValue() !== undefined}>{func(c.getValue() as V)}</Show>;
+  }
+  return {
+    defaultHeader: ((ctx) => <Header ctx={ctx} />) satisfies HeaderComponent,
+    default: ((ctx) => (
+      <Show when={ctx.getValue() != undefined}>{String(ctx.getValue())}</Show>
+    )) satisfies CellComponent,
+    decimal0: cellFunc<number>((v) => <span class="w-full text-right">{DECIMAL0_NUMBER_FORMAT.format(v)}</span>),
+    decimal2: cellFunc<number>((v) => <span class="w-full text-right">{DECIMAL2_NUMBER_FORMAT.format(v)}</span>),
+    bool: cellFunc<boolean>((v) => (v ? t("bool_values.yes") : t("bool_values.no"))),
+    date: cellFunc<string>((v) => DATE_FORMAT.format(new Date(v))),
+    datetime: cellFunc<string>((v) => DATE_TIME_FORMAT.format(new Date(v))),
+  };
+}

--- a/resources/js/components/ui/index.ts
+++ b/resources/js/components/ui/index.ts
@@ -10,3 +10,4 @@ export * from "./Table";
 export * from "./Table/tquery_filters";
 export * as css from "./css_classes";
 export * from "./form";
+export * from "./symbols";

--- a/resources/js/components/ui/symbols.tsx
+++ b/resources/js/components/ui/symbols.tsx
@@ -1,0 +1,2 @@
+/** An em-dash displayed in place of an empty value. */
+export const EMPTY_VALUE_SYMBOL = "—";

--- a/resources/js/components/utils/lang.ts
+++ b/resources/js/components/utils/lang.ts
@@ -1,12 +1,11 @@
 import {useTransContext} from "@mbarzda/solid-i18next";
 import {TOptions} from "i18next";
-import {Accessor} from "solid-js";
 
 /**
  * A wrapper for useTransContext with the basic overload options, and with better
  * types for usage as TSX attributes (no null returned).
  */
-export function useLangFunc() {
+export function useLangFunc(): LangPrefixFunc {
   const [t] = useTransContext();
   return (key: string, options?: TOptions) => (options ? t(key, options) : t(key));
 }
@@ -14,66 +13,29 @@ export function useLangFunc() {
 /** A function for getting the translation value from a particular key. */
 export type LangEntryFunc = (options?: TOptions) => string;
 
-export function getLangEntryFunc(key: string): LangEntryFunc {
-  const langFunc = useLangFunc();
-  return (options) => langFunc(key, options);
+export function getLangEntryFunc(func: LangPrefixFunc, key: string): LangEntryFunc {
+  return (options) => func(key, options);
 }
 
-export type LangSubEntryFunc = (subKey: string, options?: TOptions) => string;
+/** A function for getting the translation values from under a particular key prefix. */
+export type LangPrefixFunc = (subKey: string, options?: TOptions) => string;
 
-function isLangSubEntryParams(
-  params: Parameters<LangEntryFunc> | Parameters<LangSubEntryFunc>,
-): params is Parameters<LangSubEntryFunc> {
+function isLangPrefixParams(
+  params: Parameters<LangEntryFunc> | Parameters<LangPrefixFunc>,
+): params is Parameters<LangPrefixFunc> {
   return typeof params[0] === "string";
 }
 
-/**
- * An instance of this class represents a structure of translation keys under a prefix.
- *
- * Example:
- *
- *     // Interface representing a group of translation keys "a" and "b":
- *     const MyTranslationsInterface = new TranslationEntriesInterface("a", "b");
- *
- *     // An instance of that interface for prefix "my.prefix":
- *     const myStrings = MyTranslationsInterface.forPrefix("my.prefix");
- *
- *     // Get the translation for key "my.prefix.a" (options are optional):
- *     myStrings.a(options)
- *     // Get the translation for key "my.prefix.a.b" (options are optional):
- *     myStrings.a("b", options)
- */
-export class TranslationEntriesInterface<S extends string> {
-  private readonly suffixes;
-
-  constructor(...suffixes: S[]) {
-    this.suffixes = suffixes;
-  }
-
-  forPrefix(prefix: string | Accessor<string>) {
-    const prefixAccessor = typeof prefix === "function" ? prefix : () => prefix;
-    const langFunc = useLangFunc();
-    const result: Partial<Record<S, LangEntryFunc & LangSubEntryFunc>> = {};
-    for (const suffix of this.suffixes)
-      result[suffix] = (...params: Parameters<LangEntryFunc> | Parameters<LangSubEntryFunc>) => {
-        const [subKey, options] = isLangSubEntryParams(params) ? params : [undefined, params[0]];
-        return langFunc(`${prefixAccessor()}.${suffix}${subKey ? `.${subKey}` : ""}`, options);
-      };
-    return result as Record<S, LangEntryFunc & LangSubEntryFunc>;
-  }
+export function createTranslationsFromPrefix<S extends string>(
+  prefix: string,
+  suffixes: S[],
+): Record<S, LangEntryFunc & LangPrefixFunc> {
+  const langFunc = useLangFunc();
+  const result: Partial<Record<S, LangEntryFunc & LangPrefixFunc>> = {};
+  for (const suffix of suffixes)
+    result[suffix] = (...params: Parameters<LangEntryFunc> | Parameters<LangPrefixFunc>) => {
+      const [subKey, options] = isLangPrefixParams(params) ? params : [undefined, params[0]];
+      return langFunc(`${prefix}.${suffix}${subKey ? `.${subKey}` : ""}`, options);
+    };
+  return result as Record<S, LangEntryFunc & LangPrefixFunc>;
 }
-
-/**
- * A marker type for parameters or props that are translation entries prefix for the specified
- * TranslationEntriesInterface.
- *
- * Usage example (in a component):
- *
- *     const MyTranslationsInterface = new TranslationEntriesInterface("a", "b");
- *
- *     interface Props {
- *       translationsPrefix: TranslationEntriesPrefix<keyof MyTranslationsInterface>;
- *     }
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type TranslationEntriesPrefix<G extends TranslationEntriesInterface<string>> = string;

--- a/resources/js/features/root/pages/AdminUsersList.page.tsx
+++ b/resources/js/features/root/pages/AdminUsersList.page.tsx
@@ -1,5 +1,5 @@
 import {Row} from "@tanstack/solid-table";
-import {Email, Modal, css} from "components/ui";
+import {Email, Modal, createTableTranslations, css} from "components/ui";
 import {TQueryTable} from "components/ui/Table/TQueryTable";
 import {AccessBarrier, DATE_TIME_WITH_WEEKDAY_FORMAT} from "components/utils";
 import {Admin} from "data-access/memo-api/groups/Admin";
@@ -16,7 +16,7 @@ export default (() => {
         mode="standalone"
         staticPrefixQueryKey={Admin.keys.userLists()}
         staticEntityURL="entityURL"
-        translations="tables.tables.users"
+        staticTranslations={createTableTranslations("users")}
         intrinsicColumns={["id"]}
         additionalColumns={["actions"]}
         columnOptions={{

--- a/resources/lang/pl_PL/tables.yml
+++ b/resources/lang/pl_PL/tables.yml
@@ -1,12 +1,10 @@
 tables:
   generic:
-    empty_table_text: "Brak wyników"
     summary__zero: "Brak wyników"
     summary__one: "{{count, number}} wynik"
     summary__few: "{{count, number}} wyniki"
     summary__many: "{{count, number}} wyników"
   users:
-    empty_table_text: "Brak użytkowników"
     summary__zero: "Brak użytkowników"
     summary__one: "{{count, number}} użytkownik"
     summary__few: "{{count, number}} użytkowników"


### PR DESCRIPTION
It is now possible to easily create a non-tquery table by providing just the TanStack Table object and a couple of options to the `<Table>` component.
Cleaned up the i18n of the table - column names and summary are based on the i18n files after providing the table name. Also simplified the language interface structures which was not very good.