### PR TITLE
Fixes for ugly toast with error message:

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unused-vars": "warn",
-    "no-console": ["warn", { "allow": ["error"] }],
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-empty": "off",
     "no-inner-declarations": "off",
     "no-unused-expressions": "warn",

--- a/app/Exceptions/ValidationExceptionRenderer.php
+++ b/app/Exceptions/ValidationExceptionRenderer.php
@@ -69,7 +69,8 @@ readonly class ValidationExceptionRenderer
 
         $interpolationFields = [];
         if ($ruleTranslation) {
-            preg_match_all('/\{\{(?<field>\w+)[, ]*(?<type>\\w*)}}/', $ruleTranslation, $interpolationFields);
+            // Match the interpolation, as described here: https://www.i18next.com/translation-function/formatting
+            preg_match_all('/\{\{\s*(?<field>\w+).*?}}/', $ruleTranslation, $interpolationFields);
             $interpolationFields = array_values(
                 array_filter($interpolationFields['field'] ?? [], fn(string $a) => strtolower($a) !== 'attribute')
             );

--- a/resources/js/components/utils/InitializeTanstackQuery.tsx
+++ b/resources/js/components/utils/InitializeTanstackQuery.tsx
@@ -12,7 +12,7 @@ import {System, User} from "data-access/memo-api";
 import {Api} from "data-access/memo-api/types";
 import {For, ParentComponent, Show, VoidComponent, createMemo} from "solid-js";
 import toast from "solid-toast";
-import {useLangFunc} from ".";
+import {cx, useLangFunc} from ".";
 import {MemoLoader} from "../ui";
 
 declare module "@tanstack/query-core" {
@@ -40,21 +40,22 @@ export const InitializeTanstackQuery: ParentComponent = (props) => {
         // Validation errors will be handled by the form.
         errors = errors?.filter((e) => !Api.isValidationError(e));
       }
-      if (errors?.length)
+      if (errors?.length) {
+        const errorMessages = errors.map((e) =>
+          t(e.code, {
+            ...(Api.isValidationError(e) ? {attribute: e.field} : undefined),
+            ...e.data,
+          }),
+        );
+        for (const msg of errorMessages) {
+          console.warn(`Error toast shown: ${msg}`);
+        }
         toast.error(() => (
-          <ul class={errors!.length > 1 ? "list-disc pl-6" : undefined}>
-            <For each={errors}>
-              {(e) => (
-                <li>
-                  {t(e.code, {
-                    ...(Api.isValidationError(e) ? {attribute: e.field} : undefined),
-                    ...e.data,
-                  })}
-                </li>
-              )}
-            </For>
+          <ul class={cx({"list-disc pl-6": errorMessages.length > 1})} style={{"overflow-wrap": "anywhere"}}>
+            <For each={errorMessages}>{(msg) => <li>{msg}</li>}</For>
           </ul>
         ));
+      }
     }
   }
   const queryClient = createMemo(

--- a/resources/lang/pl_PL/validation.yml
+++ b/resources/lang/pl_PL/validation.yml
@@ -1,145 +1,134 @@
-{
-  "accepted": "Pole „{{attribute}}” musi zostać zaakceptowane.",
-  "accepted_if": "Pole „{{attribute}}” musi zostać zaakceptowane gdy „{{other}}” ma wartość {{value}}.",
-  "active_url": "Pole „{{attribute}}” jest nieprawidłowym adresem URL.",
-  "after": "Pole „{{attribute}}” musi być datą późniejszą niż {{date}}.",
-  "after_or_equal": "Pole „{{attribute}}” musi być datą nie wcześniejszą niż {{date}}.",
-  "alpha": "Pole „{{attribute}}” może zawierać jedynie litery.",
-  "alpha_dash": "Pole „{{attribute}}” może zawierać jedynie litery, cyfry i myślniki.",
-  "alpha_num": "Pole „{{attribute}}” może zawierać jedynie litery i cyfry.",
-  "array": "Pole „{{attribute}}” musi być tablicą z polami {{values}}.",
-  "ascii": "Pole „{{attribute}}” może zawierać tylko jednobajtowe znaki alfanumeryczne i symbole.",
-  "before": "Pole „{{attribute}}” musi być datą wcześniejszą niż {{date}}.",
-  "before_or_equal": "Pole „{{attribute}}” musi być datą nie późniejszą niż {{date}}.",
-  "between": {
-    "array": "Pole „{{attribute}}” musi składać się z {{min, number}} - {{max, number}} elementów.",
-    "file": "Pole „{{attribute}}” musi zawierać się w granicach {{min, number}} - {{max, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” musi zawierać się w granicach {{min, number}} - {{max, number}}.",
-    "string": "Pole „{{attribute}}” musi zawierać się w granicach {{min, number}} - {{max, number}} znaków."
-  },
-  "boolean": "Pole „{{attribute}}” musi mieć wartość logiczną prawda albo fałsz.",
-  "confirmed": "Potwierdzenie pola „{{attribute}}” nie zgadza się.",
-  "current_password": "Hasło jest nieprawidłowe.",
-  "date": "Pole „{{attribute}}” nie jest prawidłową datą.",
-  "date_equals": "Pole „{{attribute}}” musi być datą równą {{date}}.",
-  "date_format": "Pole „{{attribute}}” nie jest w formacie {{format}}.",
-  "decimal": "Pole „{{attribute}}” musi mieć {{decimal}} miejsc po przecinku.",
-  "declined": "Pole „{{attribute}}” musi zostać odrzucone.",
-  "declined_if": "Pole „{{attribute}}” musi zostać odrzucone, gdy „{{other}}” ma wartość {{value}}.",
-  "different": "Pole „{{attribute}}” oraz „{{other}}” muszą się różnić.",
-  "digits": "Pole „{{attribute}}” musi składać się z {{digits}} cyfr.",
-  "digits_between": "Pole „{{attribute}}” musi mieć od {{min}} do {{max}} cyfr.",
-  "dimensions": "Pole „{{attribute}}” ma niepoprawne wymiary.",
-  "distinct": "Pole „{{attribute}}” ma zduplikowane wartości.",
-  "doesnt_end_with": "Pole „{{attribute}}” nie może kończyć się żadną z następujących wartości: {{values}}.",
-  "doesnt_start_with": "Pole „{{attribute}}” nie może zaczynać się od żadnej z następujących wartości: {{values}}.",
-  "email": "Pole „{{attribute}}” nie jest poprawnym adresem e-mail.",
-  "ends_with": "Pole „{{attribute}}” musi kończyć się jedną z następujących wartości: {{values}}.",
-  "enum": "Pole „{{attribute}}” ma niepoprawną wartość.",
-  "exists": "Zaznaczone pole „{{attribute}}” jest nieprawidłowe.",
-  "file": "Pole „{{attribute}}” musi być plikiem.",
-  "filled": "Pole „{{attribute}}” nie może być puste.",
-  "gt": {
-    "array": "Pole „{{attribute}}” musi mieć więcej niż {{value, number}} elementów.",
-    "file": "Pole „{{attribute}}” musi być większe niż {{value, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” musi być większe niż {{value, number}}.",
-    "string": "Pole „{{attribute}}” musi być dłuższe niż {{value, number}} znaków."
-  },
-  "gte": {
-    "array": "Pole „{{attribute}}” musi mieć {{value, number}} lub więcej elementów.",
-    "file": "Pole „{{attribute}}” musi być większe lub równe {{value, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” musi być większe lub równe {{value, number}}.",
-    "string": "Pole „{{attribute}}” musi być dłuższe lub równe {{value, number}} znaków."
-  },
-  "image": "Pole „{{attribute}}” musi być obrazkiem.",
-  "in": "Zaznaczony element „{{attribute}}” musi mieć jedną z wartości: {{values}}.",
-  "in_array": "Pole „{{attribute}}” nie znajduje się w „{{other}}”.",
-  "integer": "Pole „{{attribute}}” musi być liczbą całkowitą.",
-  "ip": "Pole „{{attribute}}” musi być prawidłowym adresem IP.",
-  "ipv4": "Pole „{{attribute}}” musi być prawidłowym adresem IPv4.",
-  "ipv6": "Pole „{{attribute}}” musi być prawidłowym adresem IPv6.",
-  "json": "Pole „{{attribute}}” musi być poprawnym ciągiem znaków JSON.",
-  "lowercase": "Pole „{{attribute}}” musi być pisane małymi literami.",
-  "lt": {
-    "array": "Pole „{{attribute}}” musi mieć mniej niż {{value, number}} elementów.",
-    "file": "Pole „{{attribute}}” musi być mniejsze niż {{value, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” musi być mniejsze niż {{value, number}}.",
-    "string": "Pole „{{attribute}}” musi być krótsze niż {{value, number}} znaków."
-  },
-  "lte": {
-    "array": "Pole „{{attribute}}” musi mieć {{value, number}} lub mniej elementów.",
-    "file": "Pole „{{attribute}}” musi być mniejsze lub równe {{value, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” musi być mniejsze lub równe {{value, number}}.",
-    "string": "Pole „{{attribute}}” musi być krótsze lub równe {{value, number}} znaków."
-  },
-  "mac_address": "Pole „{{attribute}}” musi być prawidłowym adresem MAC.",
-  "max": {
-    "array": "Pole „{{attribute}}” nie może mieć więcej niż {{max, number}} elementów.",
-    "file": "Pole „{{attribute}}” nie może być większe niż {{max, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” nie może być większe niż {{max, number}}.",
-    "string": "Pole „{{attribute}}” nie może być dłuższe niż {{max, number}} znaków."
-  },
-  "max_digits": "Pole „{{attribute}}” nie może mieć więcej niż {{max}} cyfr.",
-  "mimes": "Pole „{{attribute}}” musi być plikiem typu {{values}}.",
-  "mimetypes": "Pole „{{attribute}}” musi być plikiem typu {{values}}.",
-  "min": {
-    "array": "Pole „{{attribute}}” musi mieć przynajmniej {{min, number}} elementów.",
-    "file": "Pole „{{attribute}}” musi mieć przynajmniej {{min, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” musi być nie mniejsze od {{min, number}}.",
-    "string": "Pole „{{attribute}}” musi mieć przynajmniej {{min, number}} znaków."
-  },
-  "min_digits": "Pole „{{attribute}}” musi mieć co najmniej {{min}} cyfr.",
-  "missing": "Pole „{{attribute}}” nie może występować.",
-  "missing_if": "Jeśli „{{other}}” to {{value}}, pole „{{attribute}}” nie może występować.",
-  "missing_unless": "Pole „{{attribute}}” nie może występować, chyba że „{{other}}” to {{value}}.",
-  "missing_with": "Jeśli występuje wartość {{values}}, pole „{{attribute}}” nie może występować.",
-  "missing_with_all": "Jeśli występuje {{values}}, pole „{{attribute}}” nie może występować.",
-  "multiple_of": "Pole „{{attribute}}” musi być wielokrotnością wartości {{value, number}}",
-  "not_in": "Zaznaczony „{{attribute}}” jest nieprawidłowy.",
-  "not_regex": "Format pola „{{attribute}}” jest nieprawidłowy.",
-  "numeric": "Pole „{{attribute}}” musi być liczbą.",
-  "password": {
-    "all_rules": "Pole „{{attribute}}” musi zawierać przynajmniej 8 znaków, w tym wielkie i małe litery oraz cyfry (i nie może występować w wyciekach danych).",
-    "letters": "Pole „{{attribute}}” musi zawierać przynajmniej jedną literę.",
-    "mixed": "Pole „{{attribute}}” musi zawierać przynajmniej jedną wielką i jedną małą literę.",
-    "numbers": "Pole „{{attribute}}” musi zawierać przynajmniej jedną liczbę.",
-    "symbols": "Pole „{{attribute}}” musi zawierać przynajmniej jeden symbol.",
-    "uncompromised": "Wartość „{{attribute}}” pojawiła się w wycieku danych. Proszę wybrać inną wartość „{{attribute}}”."
-  },
-  "present": "Pole „{{attribute}}” musi być obecne.",
-  "prohibited": "Pole „{{attribute}}” jest zabronione.",
-  "prohibited_if": "Pole „{{attribute}}” jest zabronione gdy „{{other}}” to {{value}}.",
-  "prohibited_unless": "Pole „{{attribute}}” jest zabronione, chyba że „{{other}}” jest w {{values}}.",
-  "prohibits": "Pole „{{attribute}}” zabrania obecności „{{other}}”.",
-  "regex": "Format pola „{{attribute}}” jest nieprawidłowy.",
-  "required": "Pole „{{attribute}}” jest wymagane.",
-  "required_array_keys": "Pole „{{attribute}}” musi zawierać wartości: {{values}}.",
-  "required_if": "Pole „{{attribute}}” jest wymagane gdy „{{other}}” ma wartość {{value}}.",
-  "required_if_accepted": "To pole jest wymagane gdy „{{other}}” jest zaakceptowane.",
-  "required_unless": "Pole „{{attribute}}” jest wymagane jeżeli „{{other}}” nie znajduje się w {{values}}.",
-  "required_with": "Pole „{{attribute}}” jest wymagane gdy {{values}} jest obecny.",
-  "required_with_all": "Pole „{{attribute}}” jest wymagane gdy wszystkie {{values}} są obecne.",
-  "required_without": "Pole „{{attribute}}” jest wymagane gdy {{values}} nie jest obecny.",
-  "required_without_all": "Pole „{{attribute}}” jest wymagane gdy żadne z {{values}} nie są obecne.",
-  "same": "Pole „{{attribute}}” i „{{other}}” muszą być takie same.",
-  "size": {
-    "array": "Pole „{{attribute}}” musi zawierać {{size, number}} elementów.",
-    "file": "Pole „{{attribute}}” musi mieć {{size, number}} kilobajtów.",
-    "numeric": "Pole „{{attribute}}” musi mieć {{size, number}}.",
-    "string": "Pole „{{attribute}}” musi mieć {{size, number}} znaków."
-  },
-  "starts_with": "Pole „{{attribute}}” musi zaczynać się jedną z następujących wartości: {{values}}.",
-  "string": "Pole „{{attribute}}” musi być ciągiem znaków.",
-  "timezone": "Pole „{{attribute}}” musi być prawidłową strefą czasową.",
-  "unique": "Taka wartość pola „{{attribute}}” już występuje.",
-  "uploaded": "Nie udało się wgrać pliku „{{attribute}}”.",
-  "uppercase": "Pole „{{attribute}}” musi być pisane wielkimi literami.",
-  "url": "Format pola „{{attribute}}” jest nieprawidłowy.",
-  "ulid": "Pole „{{attribute}}” musi być prawidłowym identyfikatorem ULID.",
-  "uuid": "Pole „{{attribute}}” musi być poprawnym identyfikatorem UUID.",
-  "custom": {
-    "require_present": "Pole „{{attribute}}” wymaga pola „{{other}}”.",
-    "data_type": "Pole „{{attribute}}” musi być typu „{{type}}”.",
-    "trimmed": "Pole „{{attribute}}” nie może się zaczynać ani kończyć białymi znakami."
-  }
-}
+# Warning: This file is also used by the backend to determine the keys in the messages. Be careful when modifying.
+accepted: "Pole „{{attribute}}” musi zostać zaakceptowane."
+accepted_if: "Pole „{{attribute}}” musi zostać zaakceptowane gdy „{{other}}” ma wartość {{value}}."
+active_url: "Pole „{{attribute}}” jest nieprawidłowym adresem URL."
+after: "Pole „{{attribute}}” musi być datą późniejszą niż {{date}}."
+after_or_equal: "Pole „{{attribute}}” musi być datą nie wcześniejszą niż {{date}}."
+alpha: "Pole „{{attribute}}” może zawierać jedynie litery."
+alpha_dash: "Pole „{{attribute}}” może zawierać jedynie litery, cyfry i myślniki."
+alpha_num: "Pole „{{attribute}}” może zawierać jedynie litery i cyfry."
+array: "Pole „{{attribute}}” musi być tablicą z polami {{values, list}}."
+ascii: "Pole „{{attribute}}” może zawierać tylko jednobajtowe znaki alfanumeryczne i symbole."
+before: "Pole „{{attribute}}” musi być datą wcześniejszą niż {{date}}."
+before_or_equal: "Pole „{{attribute}}” musi być datą nie późniejszą niż {{date}}."
+between:
+  array: "Pole „{{attribute}}” musi składać się z {{min, number}} - {{max, number}} elementów."
+  file: "Pole „{{attribute}}” musi zawierać się w granicach {{min, number}} - {{max, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” musi zawierać się w granicach {{min, number}} - {{max, number}}."
+  string: "Pole „{{attribute}}” musi zawierać się w granicach {{min, number}} - {{max, number}} znaków."
+  boolean: "Pole „{{attribute}}” musi mieć wartość logiczną prawda albo fałsz."
+confirmed: "Potwierdzenie pola „{{attribute}}” nie zgadza się."
+current_password: "Hasło jest nieprawidłowe."
+date: "Pole „{{attribute}}” nie jest prawidłową datą."
+date_equals: "Pole „{{attribute}}” musi być datą równą {{date}}."
+date_format: "Pole „{{attribute}}” nie jest w formacie {{format}}."
+decimal: "Pole „{{attribute}}” musi mieć {{decimal}} miejsc po przecinku."
+declined: "Pole „{{attribute}}” musi zostać odrzucone."
+declined_if: "Pole „{{attribute}}” musi zostać odrzucone, gdy „{{other}}” ma wartość {{value}}."
+different: "Pole „{{attribute}}” oraz „{{other}}” muszą się różnić."
+digits: "Pole „{{attribute}}” musi składać się z {{digits}} cyfr."
+digits_between: "Pole „{{attribute}}” musi mieć od {{min}} do {{max}} cyfr."
+dimensions: "Pole „{{attribute}}” ma niepoprawne wymiary."
+distinct: "Pole „{{attribute}}” ma zduplikowane wartości."
+doesnt_end_with: "Pole „{{attribute}}” nie może kończyć się żadną z następujących wartości: {{values, list(type: disjunction)}}."
+doesnt_start_with: "Pole „{{attribute}}” nie może zaczynać się od żadnej z następujących wartości: {{values, list(type: disjunction)}}."
+email: "Pole „{{attribute}}” nie jest poprawnym adresem e-mail."
+ends_with: "Pole „{{attribute}}” musi kończyć się jedną z następujących wartości: {{values, list(type: disjunction)}}."
+enum: "Pole „{{attribute}}” ma niepoprawną wartość."
+exists: "Zaznaczone pole „{{attribute}}” jest nieprawidłowe."
+file: "Pole „{{attribute}}” musi być plikiem."
+filled: "Pole „{{attribute}}” nie może być puste."
+gt:
+  array: "Pole „{{attribute}}” musi mieć więcej niż {{value, number}} elementów."
+  file: "Pole „{{attribute}}” musi być większe niż {{value, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” musi być większe niż {{value, number}}."
+  string: "Pole „{{attribute}}” musi być dłuższe niż {{value, number}} znaków."
+gte:
+  array: "Pole „{{attribute}}” musi mieć {{value, number}} lub więcej elementów."
+  file: "Pole „{{attribute}}” musi być większe lub równe {{value, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” musi być większe lub równe {{value, number}}."
+  string: "Pole „{{attribute}}” musi być dłuższe lub równe {{value, number}} znaków."
+  image: "Pole „{{attribute}}” musi być obrazkiem."
+in: "Zaznaczony element „{{attribute}}” musi mieć jedną z wartości: {{values, list(type: disjunction)}}."
+in_array: "Pole „{{attribute}}” nie znajduje się w „{{other}}”."
+integer: "Pole „{{attribute}}” musi być liczbą całkowitą."
+ip: "Pole „{{attribute}}” musi być prawidłowym adresem IP."
+ipv4: "Pole „{{attribute}}” musi być prawidłowym adresem IPv4."
+ipv6: "Pole „{{attribute}}” musi być prawidłowym adresem IPv6."
+json: "Pole „{{attribute}}” musi być poprawnym ciągiem znaków JSON."
+lowercase: "Pole „{{attribute}}” musi być pisane małymi literami."
+lt:
+  array: "Pole „{{attribute}}” musi mieć mniej niż {{value, number}} elementów."
+  file: "Pole „{{attribute}}” musi być mniejsze niż {{value, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” musi być mniejsze niż {{value, number}}."
+  string: "Pole „{{attribute}}” musi być krótsze niż {{value, number}} znaków."
+lte:
+  array: "Pole „{{attribute}}” musi mieć {{value, number}} lub mniej elementów."
+  file: "Pole „{{attribute}}” musi być mniejsze lub równe {{value, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” musi być mniejsze lub równe {{value, number}}."
+  string: "Pole „{{attribute}}” musi być krótsze lub równe {{value, number}} znaków."
+  mac_address: "Pole „{{attribute}}” musi być prawidłowym adresem MAC."
+max:
+  array: "Pole „{{attribute}}” nie może mieć więcej niż {{max, number}} elementów."
+  file: "Pole „{{attribute}}” nie może być większe niż {{max, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” nie może być większe niż {{max, number}}."
+  string: "Pole „{{attribute}}” nie może być dłuższe niż {{max, number}} znaków."
+  max_digits: "Pole „{{attribute}}” nie może mieć więcej niż {{max}} cyfr."
+mimes: "Pole „{{attribute}}” musi być plikiem typu {{values}}."
+mimetypes: "Pole „{{attribute}}” musi być plikiem typu {{values}}."
+min:
+  array: "Pole „{{attribute}}” musi mieć przynajmniej {{min, number}} elementów."
+  file: "Pole „{{attribute}}” musi mieć przynajmniej {{min, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” musi być nie mniejsze od {{min, number}}."
+  string: "Pole „{{attribute}}” musi mieć przynajmniej {{min, number}} znaków."
+  min_digits: "Pole „{{attribute}}” musi mieć co najmniej {{min}} cyfr."
+missing: "Pole „{{attribute}}” nie może występować."
+missing_if: "Jeśli „{{other}}” to {{value}}, pole „{{attribute}}” nie może występować."
+missing_unless: "Pole „{{attribute}}” nie może występować, chyba że „{{other}}” to {{value}}."
+missing_with: "Jeśli występuje wartość {{values}}, pole „{{attribute}}” nie może występować."
+missing_with_all: "Jeśli występuje {{values}}, pole „{{attribute}}” nie może występować."
+multiple_of: "Pole „{{attribute}}” musi być wielokrotnością wartości {{value, number}}"
+not_in: "Zaznaczony „{{attribute}}” jest nieprawidłowy."
+not_regex: "Format pola „{{attribute}}” jest nieprawidłowy."
+numeric: "Pole „{{attribute}}” musi być liczbą."
+password:
+  all_rules: "Pole „{{attribute}}” musi zawierać przynajmniej 8 znaków, w tym wielkie i małe litery oraz cyfry (i nie może występować w wyciekach danych)."
+  letters: "Pole „{{attribute}}” musi zawierać przynajmniej jedną literę."
+  mixed: "Pole „{{attribute}}” musi zawierać przynajmniej jedną wielką i jedną małą literę."
+  numbers: "Pole „{{attribute}}” musi zawierać przynajmniej jedną liczbę."
+  symbols: "Pole „{{attribute}}” musi zawierać przynajmniej jeden symbol."
+  uncompromised: "Wartość „{{attribute}}” pojawiła się w wycieku danych. Proszę wybrać inną wartość „{{attribute}}”."
+  present: "Pole „{{attribute}}” musi być obecne."
+prohibited: "Pole „{{attribute}}” jest zabronione."
+prohibited_if: "Pole „{{attribute}}” jest zabronione gdy „{{other}}” to {{value}}."
+prohibited_unless: "Pole „{{attribute}}” jest zabronione, chyba że „{{other}}” jest w {{values, list(type: disjunction)}}."
+prohibits: "Pole „{{attribute}}” zabrania obecności „{{other}}”."
+regex: "Format pola „{{attribute}}” jest nieprawidłowy."
+required: "Pole „{{attribute}}” jest wymagane."
+required_array_keys: "Pole „{{attribute}}” musi zawierać wartości: {{values, list(type: disjunction)}}."
+required_if: "Pole „{{attribute}}” jest wymagane gdy „{{other}}” ma wartość {{value}}."
+required_if_accepted: "To pole jest wymagane gdy „{{other}}” jest zaakceptowane."
+required_unless: "Pole „{{attribute}}” jest wymagane jeżeli „{{other}}” nie znajduje się w {{values, list(type: disjunction)}}."
+required_with: "Pole „{{attribute}}” jest wymagane gdy {{values}} jest obecny."
+required_with_all: "Pole „{{attribute}}” jest wymagane gdy wszystkie {{values, list}} są obecne."
+required_without: "Pole „{{attribute}}” jest wymagane gdy {{values}} nie jest obecny."
+required_without_all: "Pole „{{attribute}}” jest wymagane gdy żadne z {{values, list(type: disjunction)}} nie są obecne."
+same: "Pole „{{attribute}}” i „{{other}}” muszą być takie same."
+size:
+  array: "Pole „{{attribute}}” musi zawierać {{size, number}} elementów."
+  file: "Pole „{{attribute}}” musi mieć {{size, number}} kilobajtów."
+  numeric: "Pole „{{attribute}}” musi mieć {{size, number}}."
+  string: "Pole „{{attribute}}” musi mieć {{size, number}} znaków."
+  starts_with: "Pole „{{attribute}}” musi zaczynać się jedną z następujących wartości: {{values, list(type: disjunction)}}."
+string: "Pole „{{attribute}}” musi być ciągiem znaków."
+timezone: "Pole „{{attribute}}” musi być prawidłową strefą czasową."
+unique: "Taka wartość pola „{{attribute}}” już występuje."
+uploaded: "Nie udało się wgrać pliku „{{attribute}}”."
+uppercase: "Pole „{{attribute}}” musi być pisane wielkimi literami."
+url: "Format pola „{{attribute}}” jest nieprawidłowy."
+ulid: "Pole „{{attribute}}” musi być prawidłowym identyfikatorem ULID."
+uuid: "Pole „{{attribute}}” musi być poprawnym identyfikatorem UUID."
+custom:
+  require_present: "Pole „{{attribute}}” wymaga pola „{{other}}”."
+  data_type: "Pole „{{attribute}}” musi być typu „{{type}}”."
+  trimmed: "Pole „{{attribute}}” nie może się zaczynać ani kończyć białymi znakami."


### PR DESCRIPTION
- Format values lists in validation errors as lists (this inserts spaces between them).
- Fixed a regexp on the backend to still parse the validations file correctly.
- Force the error messages in toast to wrap instead of overflowing, even if there are no spaces.
- Also console.warn the errors, so that they are not lost once they disappear from screen (might be helpful when debugging).
- Also reformatted validation.yml as typical YAML, and added a warning that backend also uses the file.