### PR TITLE
Fz 87 attribute table

### DIFF
--- a/app/Http/Controllers/SystemController.php
+++ b/app/Http/Controllers/SystemController.php
@@ -6,6 +6,7 @@ use App\Http\Permissions\Permission;
 use App\Http\Permissions\PermissionDescribe;
 use App\Http\Resources\DictionaryResource;
 use App\Http\Resources\FacilityResource;
+use App\Models\Attribute;
 use App\Models\Dictionary;
 use App\Models\Facility;
 use App\Services\System\TranslationsService;
@@ -83,5 +84,30 @@ class SystemController extends ApiController
         $dictionariesQuery = Dictionary::query();
         $this->applyRequestIn($dictionariesQuery);
         return DictionaryResource::collection($dictionariesQuery->with(['positions'])->get());
+    }
+
+    #[OA\Get(
+        path: '/api/v1/system/attribute/list',
+        description: new PermissionDescribe(Permission::any),
+        summary: 'All attributes',
+        tags: ['System'],
+        parameters: [new OA\Parameter(name: 'in', in: 'query')],
+        responses: [
+            new OA\Response(
+                response: 200, description: 'OK', content: new  OA\JsonContent(properties: [
+                new OA\Property(
+                    property: 'data', type: 'array', items: new OA\Items(
+                    ref: '#/components/schemas/AttributeResource'
+                ),
+                ),
+            ])
+            ),
+        ]
+    )]
+    public function attributeList(): JsonResource
+    {
+        $attributesQuery = Attribute::query();
+        $this->applyRequestIn($attributesQuery);
+        return DictionaryResource::collection($attributesQuery->get());
     }
 }

--- a/app/Http/Controllers/SystemController.php
+++ b/app/Http/Controllers/SystemController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Permissions\Permission;
 use App\Http\Permissions\PermissionDescribe;
+use App\Http\Resources\AttributeResource;
 use App\Http\Resources\DictionaryResource;
 use App\Http\Resources\FacilityResource;
 use App\Models\Attribute;
@@ -108,6 +109,6 @@ class SystemController extends ApiController
     {
         $attributesQuery = Attribute::query();
         $this->applyRequestIn($attributesQuery);
-        return DictionaryResource::collection($attributesQuery->get());
+        return AttributeResource::collection($attributesQuery->get());
     }
 }

--- a/app/Http/Resources/AttributeResource.php
+++ b/app/Http/Resources/AttributeResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Models\Attribute;
 use App\Models\Dictionary;
 use App\Models\Enums\AttributeModel;
 use App\Models\Enums\AttributeRequirementLevel;
@@ -14,19 +15,19 @@ use OpenApi\Attributes as OA;
     properties: [
         new OA\Property(property: 'id', type: 'string', format: 'uuid', example: 'UUID'),
         new OA\Property(property: 'facilityId', type: 'string', format: 'uuid', example: 'UUID', nullable: true),
-        new OA\Property(property: 'table', type: 'string', enum: AttributeTable::class , example: 'users'),
-        new OA\Property(property: 'model', type: 'string', enum: AttributeModel::class , example: 'user'),
+        new OA\Property(property: 'table', type: 'string', enum: AttributeTable::class, example: 'users'),
+        new OA\Property(property: 'model', type: 'string', enum: AttributeModel::class, example: 'user'),
         new OA\Property(property: 'name', type: 'string', example: 'attribute'),
-        new OA\Property(property: 'api_name', type: 'string', example: 'attribute'),
-        new OA\Property(property: 'type', type: 'string', enum: AttributeType::class , example: 'decimal0'),
+        new OA\Property(property: 'apiName', type: 'string', example: 'attribute'),
+        new OA\Property(property: 'type', type: 'string', enum: AttributeType::class, example: 'decimal0'),
         new OA\Property(property: 'dictionaryId', type: 'string', format: 'uuid', example: 'UUID', nullable: true),
         new OA\Property(property: 'defaultOrder', type: 'int', example: 1),
         new OA\Property(property: 'isMultiValue', type: 'bool', example: false, nullable: true),
-        new OA\Property(property: 'requirementLevel', type: 'string', enum: AttributeRequirementLevel::class , example: 'required'),
+        new OA\Property(property: 'requirementLevel', type: 'string', enum: AttributeRequirementLevel::class, example: 'required'),
     ]
 )] /**
- * @method __construct(Dictionary $resource)
- * @mixin Dictionary
+ * @method __construct(Attribute $resource)
+ * @mixin Attribute
  */
 class AttributeResource extends AbstractJsonResource
 {
@@ -35,16 +36,16 @@ class AttributeResource extends AbstractJsonResource
     {
         return [
             'id' => true,
-            'facility_id' => true,
+            'facilityId' => true,
             'table' => true,
             'model' => true,
             'name' => true,
-            'api_name' => true,
+            'apiName' => true,
             'type' => true,
-            'dictionary_id' => true,
-            'default_order' => true,
-            'is_multi_value' => true,
-            'requirement_level' => true,
+            'dictionaryId' => true,
+            'defaultOrder' => true,
+            'isMultiValue' => true,
+            'requirementLevel' => true,
         ];
     }
 }

--- a/app/Http/Resources/AttributeResource.php
+++ b/app/Http/Resources/AttributeResource.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Dictionary;
+use App\Models\Enums\AttributeModel;
+use App\Models\Enums\AttributeRequirementLevel;
+use App\Models\Enums\AttributeTable;
+use App\Models\Enums\AttributeType;
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'AttributeResource',
+    properties: [
+        new OA\Property(property: 'id', type: 'string', format: 'uuid', example: 'UUID'),
+        new OA\Property(property: 'facilityId', type: 'string', format: 'uuid', example: 'UUID', nullable: true),
+        new OA\Property(property: 'table', type: 'string', enum: AttributeTable::class , example: 'users'),
+        new OA\Property(property: 'model', type: 'string', enum: AttributeModel::class , example: 'user'),
+        new OA\Property(property: 'name', type: 'string', example: 'attribute'),
+        new OA\Property(property: 'api_name', type: 'string', example: 'attribute'),
+        new OA\Property(property: 'type', type: 'string', enum: AttributeType::class , example: 'decimal0'),
+        new OA\Property(property: 'dictionaryId', type: 'string', format: 'uuid', example: 'UUID', nullable: true),
+        new OA\Property(property: 'defaultOrder', type: 'int', example: 1),
+        new OA\Property(property: 'isMultiValue', type: 'bool', example: false, nullable: true),
+        new OA\Property(property: 'requirementLevel', type: 'string', enum: AttributeRequirementLevel::class , example: 'required'),
+    ]
+)] /**
+ * @method __construct(Dictionary $resource)
+ * @mixin Dictionary
+ */
+class AttributeResource extends AbstractJsonResource
+{
+
+    protected static function getMappedFields(): array
+    {
+        return [
+            'id' => true,
+            'facility_id' => true,
+            'table' => true,
+            'model' => true,
+            'name' => true,
+            'api_name' => true,
+            'type' => true,
+            'dictionary_id' => true,
+            'default_order' => true,
+            'is_multi_value' => true,
+            'requirement_level' => true,
+        ];
+    }
+}

--- a/app/Models/Attribute.php
+++ b/app/Models/Attribute.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Enums\AttributeModel;
+use App\Models\Enums\AttributeRequirementLevel;
+use App\Models\Enums\AttributeTable;
+use App\Models\Enums\AttributeType;
+use App\Models\QueryBuilders\AttributeBuilder;
+use App\Utils\Uuid\UuidTrait;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string id
+ * @property ?string facility_id
+ * @property AttributeTable table
+ * @property AttributeModel model
+ * @property string name
+ * @property string api_name
+ * @property AttributeType type
+ * @property ?string dictionary_id
+ * @property int default_order
+ * @property ?bool is_multi_value
+ * @property AttributeRequirementLevel requirement_level
+ * @property CarbonImmutable created_at
+ * @property CarbonImmutable updated_at
+ * @method static AttributeBuilder query()
+ */
+class Attribute extends Model
+{
+    use HasFactory;
+    use UuidTrait;
+
+    protected $table = 'attributes';
+
+    protected $fillable = [
+        'facility_id',
+        'table',
+        'model',
+        'api_name',
+        'type',
+        'dictionary_id',
+        'default_order',
+        'is_multi_value',
+        'requirement_level',
+    ];
+
+    protected $casts = [
+        'created_at' => 'immutable_datetime',
+        'updated_at' => 'immutable_datetime',
+        'table' => AttributeTable::class,
+        'model' => AttributeModel::class,
+        'type' => AttributeType::class,
+        'is_multi_value' => 'boolean',
+        'requirement_level' => AttributeRequirementLevel::class,
+    ];
+}

--- a/app/Models/Enums/AttributeModel.php
+++ b/app/Models/Enums/AttributeModel.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Models\Enums;
+
+enum AttributeModel: string
+{
+    case USER = 'user';
+    case CLIENT = 'client';
+}

--- a/app/Models/Enums/AttributeModel.php
+++ b/app/Models/Enums/AttributeModel.php
@@ -4,6 +4,6 @@ namespace App\Models\Enums;
 
 enum AttributeModel: string
 {
-    case USER = 'user';
-    case CLIENT = 'client';
+    case User = 'user';
+    case Client = 'client';
 }

--- a/app/Models/Enums/AttributeRequirementLevel.php
+++ b/app/Models/Enums/AttributeRequirementLevel.php
@@ -4,8 +4,8 @@ namespace App\Models\Enums;
 
 enum AttributeRequirementLevel: string
 {
-    case REQUIRED = 'required';
-    case RECOMMENDED = 'recommended';
-    case OPTIONAL = 'optional';
-    case EMPTY = 'empty';
+    case Required = 'required';
+    case Recommended = 'recommended';
+    case Optional = 'optional';
+    case Empty = 'empty';
 }

--- a/app/Models/Enums/AttributeRequirementLevel.php
+++ b/app/Models/Enums/AttributeRequirementLevel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Enums;
+
+enum AttributeRequirementLevel: string
+{
+    case REQUIRED = 'required';
+    case RECOMMENDED = 'recommended';
+    case OPTIONAL = 'optional';
+    case EMPTY = 'empty';
+}

--- a/app/Models/Enums/AttributeTable.php
+++ b/app/Models/Enums/AttributeTable.php
@@ -4,6 +4,6 @@ namespace App\Models\Enums;
 
 enum AttributeTable: string
 {
-    case USERS = 'users';
-    case CLIENTS = 'clients';
+    case Users = 'users';
+    case Clients = 'clients';
 }

--- a/app/Models/Enums/AttributeTable.php
+++ b/app/Models/Enums/AttributeTable.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Models\Enums;
+
+enum AttributeTable: string
+{
+    case USERS = 'users';
+    case CLIENTS = 'clients';
+}

--- a/app/Models/Enums/AttributeType.php
+++ b/app/Models/Enums/AttributeType.php
@@ -5,14 +5,14 @@ namespace App\Models\Enums;
 enum AttributeType: string
 {
     // Standard data types.
-    case STRING = 'string';
-    case DECIMAL0 = 'decimal0';
-    case DECIMAL2 = 'decimal2';
-    case BOOL = 'bool';
-    case DATE = 'date';
-    case DATETIME = 'datetime';
+    case Bool = 'bool';
+    case Date = 'date';
+    case Datetime = 'datetime';
+    case Int = 'int';
+    case String = 'string';
     // Supported table names.
-    case USERS = 'users';
+    case Users = 'users';
+    case Clients = 'clients';
     // Dictionary.
-    case DICT = 'dict';
+    case Dict = 'dict';
 }

--- a/app/Models/Enums/AttributeType.php
+++ b/app/Models/Enums/AttributeType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Enums;
+
+enum AttributeType: string
+{
+    // Standard data types.
+    case STRING = 'string';
+    case DECIMAL0 = 'decimal0';
+    case DECIMAL2 = 'decimal2';
+    case BOOL = 'bool';
+    case DATE = 'date';
+    case DATETIME = 'datetime';
+    // Supported table names.
+    case USERS = 'users';
+    // Dictionary.
+    case DICT = 'dict';
+}

--- a/app/Models/QueryBuilders/AttributeBuilder.php
+++ b/app/Models/QueryBuilders/AttributeBuilder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models\QueryBuilders;
+
+use App\Models\Client as BuilderModel;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * @method Collection|BuilderModel[] get(string[] $columns = ['*'])
+ * @method BuilderModel|null find(string $id)
+ * @method BuilderModel findOrFail(string $id)
+ * @method self with(array $relations)
+ * @method BuilderModel newModelInstance(array $attributes = [])
+ */
+class AttributeBuilder
+{
+}

--- a/app/Models/QueryBuilders/AttributeBuilder.php
+++ b/app/Models/QueryBuilders/AttributeBuilder.php
@@ -3,6 +3,7 @@
 namespace App\Models\QueryBuilders;
 
 use App\Models\Client as BuilderModel;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
@@ -12,6 +13,6 @@ use Illuminate\Database\Eloquent\Collection;
  * @method self with(array $relations)
  * @method BuilderModel newModelInstance(array $attributes = [])
  */
-class AttributeBuilder
+class AttributeBuilder  extends Builder
 {
 }

--- a/database/factories/AttributeFactory.php
+++ b/database/factories/AttributeFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Attribute>
+ */
+class AttributeFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/2023_10_28_162444_create_attributes_table.php
+++ b/database/migrations/2023_10_28_162444_create_attributes_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('attributes', function (Blueprint $table) {
+            $table->char('id', 36)->collation('ascii_bin')->primary();
+            $table->char('facility_id', 36)->collation('ascii_bin')->nullable();
+            $table->char('table');
+            $table->char('model');
+            $table->char('name');
+            $table->char('api_name');
+            $table->char('type');
+            $table->char('dictionary_id', 36)->collation('ascii_bin')->nullable();
+            $table->integer('default_order');
+            $table->boolean('is_multi_value')->nullable();
+            $table->char('requirement_level');
+
+
+
+            $table->timestamps();
+
+            $table->foreign('facility_id')
+                ->references('id')
+                ->on('facilities')
+                // Null has special meaning in this table ('any facility'), maybe it should restrict or cascade
+                //(otherwise facility-specific attributes become available to everyone).
+                ->onDelete('set null');
+
+            $table->foreign('dictionary_id')
+                ->references('id')
+                ->on('dictionaries')
+                ->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('attributes');
+    }
+};

--- a/database/migrations/2023_10_28_162444_create_attributes_table.php
+++ b/database/migrations/2023_10_28_162444_create_attributes_table.php
@@ -13,31 +13,29 @@ return new class extends Migration {
         Schema::create('attributes', function (Blueprint $table) {
             $table->char('id', 36)->collation('ascii_bin')->primary();
             $table->char('facility_id', 36)->collation('ascii_bin')->nullable();
-            $table->char('table');
-            $table->char('model');
-            $table->char('name');
-            $table->char('api_name');
-            $table->char('type');
+            $table->string('table', 36)->collation('ascii_bin');
+            $table->string('model', 36)->collation('ascii_bin');
+            $table->string('name');
+            $table->string('api_name')->collation('ascii_bin');
+            $table->string('type', 36)->collation('ascii_bin');
             $table->char('dictionary_id', 36)->collation('ascii_bin')->nullable();
             $table->integer('default_order');
             $table->boolean('is_multi_value')->nullable();
-            $table->char('requirement_level');
-
-
-
-            $table->timestamps();
+            $table->string('requirement_level', 36)->collation('ascii_bin');
+            $table->dateTime('created_at');
+            $table->dateTime('updated_at');
 
             $table->foreign('facility_id')
                 ->references('id')
                 ->on('facilities')
-                // Null has special meaning in this table ('any facility'), maybe it should restrict or cascade
-                //(otherwise facility-specific attributes become available to everyone).
-                ->onDelete('set null');
+                // Setting null would men that a facility-specific attribute becomes available for everyone.
+                ->restrictOnDelete();
 
             $table->foreign('dictionary_id')
                 ->references('id')
                 ->on('dictionaries')
-                ->onDelete('set null');
+                // Setting null would make that attribute loose connection to dictionary, while still having type 'dict', making it invalid.
+                ->restrictOnDelete();
         });
     }
 

--- a/database/migrations/2023_11_01_150241_attributes_add_gender.php
+++ b/database/migrations/2023_11_01_150241_attributes_add_gender.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -7,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    private string $genderAttrbuteId = '0e56d086-5bf7-46c0-8359-38e9edf8c627';
+    private string $genderAttributeId = '0e56d086-5bf7-46c0-8359-38e9edf8c627';
     private string $gender_column_name = 'gender_dict_id';
 
     /**
@@ -18,41 +19,25 @@ return new class extends Migration
         Schema::table('clients', function (Blueprint $table) {
             $table->char($this->gender_column_name, 36)->collation('ascii_bin')->nullable();
         });
+
         $genderDictionaryId = 'c21c1557-4617-42ae-ad20-12f8f89fb12b';
+        $timestamp = CarbonImmutable::now();
         // Add row to attributes table
-        DB::statement(<<<INSERT
-            insert into attributes (
-                                    id,
-                                    facility_id,
-                                    `table`,
-                                    model,
-                                    name,
-                                    api_name,
-                                    type,
-                                    dictionary_id,
-                                    default_order,
-                                    is_multi_value,
-                                    requirement_level,
-                                    created_at,
-                                    updated_at
-                                    )
-            values (
-                    '$this->genderAttrbuteId',
-                    null,
-                    'clients',
-                    'client',
-                    'gender',
-                    '$this->gender_column_name',
-                    'dict',
-                    '$genderDictionaryId',
-                    1,
-                    null,
-                    'recommended',
-                    CURRENT_TIMESTAMP(),
-                    CURRENT_TIMESTAMP()
-                    );
-            INSERT
-        );
+        DB::table('attributes')->insertOrIgnore([
+            'id' => $this->genderAttributeId,
+            'facility_id' => null,
+            'table' => 'clients',
+            'model' => 'client',
+            'name' => 'gender',
+            'api_name' => $this->gender_column_name,
+            'type' => 'dict',
+            'dictionary_id' => $genderDictionaryId,
+            'default_order' => 1,
+            'is_multi_value' => null,
+            'requirement_level' => 'recommended',
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
 
     }
 
@@ -61,7 +46,8 @@ return new class extends Migration
      */
     public function down(): void
     {
-        DB::statement("DELETE FROM attributes where id = '$this->genderAttrbuteId';");
+        DB::table('attributes')->delete($this->genderAttributeId);
+
         Schema::table('clients', function (Blueprint $table) {
             $table->dropColumn($this->gender_column_name);
         });

--- a/database/migrations/2023_11_01_150241_attributes_add_gender.php
+++ b/database/migrations/2023_11_01_150241_attributes_add_gender.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private string $genderAttrbuteId = '0e56d086-5bf7-46c0-8359-38e9edf8c627';
+    private string $gender_column_name = 'gender_dict_id';
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('clients', function (Blueprint $table) {
+            $table->char($this->gender_column_name, 36)->collation('ascii_bin')->nullable();
+        });
+        $genderDictionaryId = 'c21c1557-4617-42ae-ad20-12f8f89fb12b';
+        // Add row to attributes table
+        DB::statement(<<<INSERT
+            insert into attributes (
+                                    id,
+                                    facility_id,
+                                    `table`,
+                                    model,
+                                    name,
+                                    api_name,
+                                    type,
+                                    dictionary_id,
+                                    default_order,
+                                    is_multi_value,
+                                    requirement_level,
+                                    created_at,
+                                    updated_at
+                                    )
+            values (
+                    '$this->genderAttrbuteId',
+                    null,
+                    'clients',
+                    'client',
+                    'gender',
+                    '$this->gender_column_name',
+                    'dict',
+                    '$genderDictionaryId',
+                    1,
+                    null,
+                    'recommended',
+                    CURRENT_TIMESTAMP(),
+                    CURRENT_TIMESTAMP()
+                    );
+            INSERT
+        );
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("DELETE FROM attributes where id = '$this->genderAttrbuteId';");
+        Schema::table('clients', function (Blueprint $table) {
+            $table->dropColumn($this->gender_column_name);
+        });
+    }
+};

--- a/resources/lang/pl_PL/models.yml
+++ b/resources/lang/pl_PL/models.yml
@@ -59,3 +59,7 @@ user:
   hasEmailVerified: "e-mail zweryfikowany"
   members: "przypisane placówki"
   facilityCount: "liczba placówek"
+clients:
+  _name: "klient"
+  _name_plural: "klienci"
+  gender_dict_id: "$t(dictionary.gender._name)"

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,9 @@ Route::prefix('/v1')->group(function () {
         Route::prefix('/dictionary')->group(function () {
             Route::get('/list', [SystemController::class, 'dictionaryList']);
         });
+        Route::prefix('/attribute')->group(function () {
+            Route::get('/list', [SystemController::class, 'attributeList']);
+        });
     });
     Route::prefix('/user')->group(function () {
         Route::patch('', [UserController::class, 'patch']);


### PR DESCRIPTION
Some decisions I made that could be debated:

* used strings for db enums ([some rationale](https://komlenic.com/244/8-reasons-why-mysqls-enum-data-type-is-evil/)), on PHP side those are string backed enums (could be numbers for storage reason, but that makes viewing the data annoying and would require translation for meaningful API responses).
* I did add foreign key constraints on attributes (for validation), but didn't add methods for fetching those on the model (can be added later if required).
* Which `attributes` columns do we actually want to expose via API? for now I exposed the table 1:1.

No i znowu napisałem to odruchowo po angielsku, nie chce mi się już przepisywać:D