### PR TITLE
FZ-112 meeting type/category dictionary, some fixes to old migrations

### DIFF
--- a/database/migrations/2023_03_08_221802_add_system_user.php
+++ b/database/migrations/2023_03_08_221802_add_system_user.php
@@ -10,7 +10,7 @@ return new class extends Migration {
      * Run the migrations.
      */
     private string $systemUserId = 'e144ff18-471f-456f-a1c2-971d88b3d213';
-    private string $startDate = '2022-03-08 00:00:00';
+    private string $startDate = '2023-03-08 00:00:00';
 
     public function up(): void
     {

--- a/database/migrations/2023_07_13_182809_dictionaries_and_positions.php
+++ b/database/migrations/2023_07_13_182809_dictionaries_and_positions.php
@@ -11,71 +11,261 @@ return new class extends Migration {
      */
     public function up(): void
     {
-          Schema::create('dictionaries', function (Blueprint $table) {
-              $table->char('id', 36)->collation('ascii_bin')->primary();
-              $table->char('facility_id', 36)->collation('ascii_bin')->nullable();
-              $table->string('name');
-              $table->boolean('is_fixed');
+        Schema::create('dictionaries', function (Blueprint $table) {
+            $table->char('id', 36)->collation('ascii_bin')->primary();
+            $table->char('facility_id', 36)->collation('ascii_bin')->nullable();
+            $table->string('name');
+            $table->boolean('is_fixed');
 
-              $table->char('created_by', 36)->collation('ascii_bin');
-              $table->dateTime('created_at');
-              $table->dateTime('updated_at');
+            $table->char('created_by', 36)->collation('ascii_bin');
+            $table->dateTime('created_at');
+            $table->dateTime('updated_at');
 
-              $table->foreign('facility_id')->references('id')->on('facilities');
-              $table->foreign('created_by')->references('id')->on('users');
-          });
-          Schema::create('positions', function (Blueprint $table) {
-              $table->char('id', 36)->collation('ascii_bin')->primary();
-              $table->char('dictionary_id', 36)->collation('ascii_bin');
-              $table->char('facility_id', 36)->collation('ascii_bin')->nullable();
-              $table->string('name');
-              $table->boolean('is_fixed');
-              $table->integer('default_order');
+            $table->foreign('facility_id')->references('id')->on('facilities');
+            $table->foreign('created_by')->references('id')->on('users');
+        });
+        Schema::create('positions', function (Blueprint $table) {
+            $table->char('id', 36)->collation('ascii_bin')->primary();
+            $table->char('dictionary_id', 36)->collation('ascii_bin');
+            $table->char('facility_id', 36)->collation('ascii_bin')->nullable();
+            $table->string('name');
+            $table->boolean('is_fixed');
+            $table->integer('default_order');
 
-              $table->char('created_by', 36)->collation('ascii_bin');
-              $table->dateTime('created_at');
-              $table->dateTime('updated_at');
+            $table->char('created_by', 36)->collation('ascii_bin');
+            $table->dateTime('created_at');
+            $table->dateTime('updated_at');
 
-              $table->unique(['dictionary_id', 'default_order']);
-              $table->foreign('dictionary_id')->references('id')->on('dictionaries');
-              $table->foreign('facility_id')->references('id')->on('facilities');
-              $table->foreign('created_by')->references('id')->on('users');
-          });
+            $table->unique(['dictionary_id', 'default_order']);
+            $table->foreign('dictionary_id')->references('id')->on('dictionaries');
+            $table->foreign('facility_id')->references('id')->on('facilities');
+            $table->foreign('created_by')->references('id')->on('users');
+        });
 
-        $date = "'2022-07-13 00:00:00'";
-        $systemUserId = "'e144ff18-471f-456f-a1c2-971d88b3d213'";
-        DB::statement(
-            <<<"SQL"
-            insert into dictionaries (id, name, is_fixed, created_by, created_at, updated_at) values
-            ('c21c1557-4617-42ae-ad20-12f8f89fb12b', 'gender', 1, $systemUserId, $date, $date),
-            ('d96a602d-c10f-4e9d-a3ad-4c450efa7717', 'pl_voivodeship', 1, $systemUserId, $date, $date);
-SQL
-        );
-        DB::statement(
-            <<<"SQL"
-            insert into positions (id, dictionary_id, name, is_fixed, default_order, created_by, created_at, updated_at) values
-            ('1f3e095c-938b-4367-b3cc-7ef25ab1de70', 'c21c1557-4617-42ae-ad20-12f8f89fb12b', 'female', 1, 1, $systemUserId, $date, $date),
-            ('4b694d4e-2447-4e15-aba4-d24ac769da49', 'c21c1557-4617-42ae-ad20-12f8f89fb12b', 'male', 1, 2, $systemUserId, $date, $date),
-            ('51293720-2cd2-4072-b692-4bd4fe7587dc', 'c21c1557-4617-42ae-ad20-12f8f89fb12b', 'other', 1, 3, $systemUserId, $date, $date),
-            ('eeb429d1-a804-44b3-9cd6-1f9f45dfce48', 'c21c1557-4617-42ae-ad20-12f8f89fb12b', 'unknown', 1, 4, $systemUserId, $date, $date),
-            ('4afca5eb-9992-40c7-8471-106881d30061', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+dolnośląskie', 1, 2, $systemUserId, $date, $date),
-            ('7f8494e4-ee0a-434e-bb7f-7d1cff2d2f0e', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+kujawsko-pomorskie', 1, 4, $systemUserId, $date, $date),
-            ('8209b8c1-b79e-4e87-a6b1-13019e51f3fb', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+lubelskie', 1, 6, $systemUserId, $date, $date),
-            ('fff916bd-aad2-47e0-a9bc-42f99deb48c5', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+lubuskie', 1, 8, $systemUserId, $date, $date),
-            ('662d9bab-2471-4b9e-9d77-c34eb5def56b', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+łódzkie', 1, 10, $systemUserId, $date, $date),
-            ('686f53b4-7f4d-4992-b6fd-072bb08543a1', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+małopolskie', 1, 12, $systemUserId, $date, $date),
-            ('724dc49b-5ab9-4ca7-b88a-d7c37d3c050f', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+mazowieckie', 1, 14, $systemUserId, $date, $date),
-            ('1ba5a225-6189-43da-9053-416a747db326', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+opolskie', 1, 16, $systemUserId, $date, $date),
-            ('4e17613f-3c94-416a-916a-bc239a0ba311', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+podkarpackie', 1, 18, $systemUserId, $date, $date),
-            ('bc7b76de-d81f-4359-9d08-c89e567af3c4', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+podlaskie', 1, 20, $systemUserId, $date, $date),
-            ('e141f09c-03e0-436f-a748-0530e1ccb0b5', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+pomorskie', 1, 22, $systemUserId, $date, $date),
-            ('f9d4ace3-36b8-4f34-bdc7-39e69dc0dd21', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+śląskie', 1, 24, $systemUserId, $date, $date),
-            ('57301758-86ab-4660-8acf-69ea3d11f78b', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+świętokrzyskie', 1, 26, $systemUserId, $date, $date),
-            ('4a0e4408-c0dc-4ffd-98e7-1aa0620453cd', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+warmińsko-mazurskie', 1, 28, $systemUserId, $date, $date),
-            ('e0deb63c-9283-4024-8804-ac7418ef9b3b', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+wielkopolskie', 1, 30, $systemUserId, $date, $date),
-            ('75059b8f-0c73-46b5-a48a-0fd45864b3d4', 'd96a602d-c10f-4e9d-a3ad-4c450efa7717', '+zachodniopomorskie', 1, 32, $systemUserId, $date, $date);
-SQL
-        );
+        $date = '2023-07-13 00:00:00';
+        $systemUserId = 'e144ff18-471f-456f-a1c2-971d88b3d213';
+
+        DB::table('dictionaries')->insertOrIgnore([
+            [
+                'id' => 'c21c1557-4617-42ae-ad20-12f8f89fb12b',
+                'name' => 'gender',
+                'is_fixed' => true,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => 'pl_voivodeship',
+                'is_fixed' => true,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+        ]);
+
+        DB::table('positions')->insert([
+            [
+                'id' => '1f3e095c-938b-4367-b3cc-7ef25ab1de70',
+                'dictionary_id' => 'c21c1557-4617-42ae-ad20-12f8f89fb12b',
+                'name' => 'female',
+                'is_fixed' => true,
+                'default_order' => 1,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '4b694d4e-2447-4e15-aba4-d24ac769da49',
+                'dictionary_id' => 'c21c1557-4617-42ae-ad20-12f8f89fb12b',
+                'name' => 'male',
+                'is_fixed' => true,
+                'default_order' => 2,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '51293720-2cd2-4072-b692-4bd4fe7587dc',
+                'dictionary_id' => 'c21c1557-4617-42ae-ad20-12f8f89fb12b',
+                'name' => 'other',
+                'is_fixed' => true,
+                'default_order' => 3,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => 'eeb429d1-a804-44b3-9cd6-1f9f45dfce48',
+                'dictionary_id' => 'c21c1557-4617-42ae-ad20-12f8f89fb12b',
+                'name' => 'unknown',
+                'is_fixed' => true,
+                'default_order' => 4,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '4afca5eb-9992-40c7-8471-106881d30061',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+dolnośląskie',
+                'is_fixed' => true,
+                'default_order' => 2,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '7f8494e4-ee0a-434e-bb7f-7d1cff2d2f0e',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+kujawsko-pomorskie',
+                'is_fixed' => true,
+                'default_order' => 4,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '8209b8c1-b79e-4e87-a6b1-13019e51f3fb',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+lubelskie',
+                'is_fixed' => true,
+                'default_order' => 6,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => 'fff916bd-aad2-47e0-a9bc-42f99deb48c5',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+lubuskie',
+                'is_fixed' => true,
+                'default_order' => 8,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '662d9bab-2471-4b9e-9d77-c34eb5def56b',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+łódzkie',
+                'is_fixed' => true,
+                'default_order' => 10,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '686f53b4-7f4d-4992-b6fd-072bb08543a1',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+małopolskie',
+                'is_fixed' => true,
+                'default_order' => 12,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '724dc49b-5ab9-4ca7-b88a-d7c37d3c050f',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+mazowieckie',
+                'is_fixed' => true,
+                'default_order' => 14,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '1ba5a225-6189-43da-9053-416a747db326',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+opolskie',
+                'is_fixed' => true,
+                'default_order' => 16,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '4e17613f-3c94-416a-916a-bc239a0ba311',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+podkarpackie',
+                'is_fixed' => true,
+                'default_order' => 18,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => 'bc7b76de-d81f-4359-9d08-c89e567af3c4',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+podlaskie',
+                'is_fixed' => true,
+                'default_order' => 20,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => 'e141f09c-03e0-436f-a748-0530e1ccb0b5',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+pomorskie',
+                'is_fixed' => true,
+                'default_order' => 22,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => 'f9d4ace3-36b8-4f34-bdc7-39e69dc0dd21',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+śląskie',
+                'is_fixed' => true,
+                'default_order' => 24,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '57301758-86ab-4660-8acf-69ea3d11f78b',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+świętokrzyskie',
+                'is_fixed' => true,
+                'default_order' => 26,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '4a0e4408-c0dc-4ffd-98e7-1aa0620453cd',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+warmińsko-mazurskie',
+                'is_fixed' => true,
+                'default_order' => 28,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => 'e0deb63c-9283-4024-8804-ac7418ef9b3b',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+wielkopolskie',
+                'is_fixed' => true,
+                'default_order' => 30,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '75059b8f-0c73-46b5-a48a-0fd45864b3d4',
+                'dictionary_id' => 'd96a602d-c10f-4e9d-a3ad-4c450efa7717',
+                'name' => '+zachodniopomorskie',
+                'is_fixed' => true,
+                'default_order' => 32,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+        ]);
     }
 
     /**
@@ -83,7 +273,7 @@ SQL
      */
     public function down(): void
     {
-        Schema::drop('positions');
-        Schema::drop('dictionaries');
+        Schema::dropIfExists('positions');
+        Schema::dropIfExists('dictionaries');
     }
 };

--- a/database/migrations/2023_07_13_182809_dictionaries_and_positions.php
+++ b/database/migrations/2023_07_13_182809_dictionaries_and_positions.php
@@ -45,7 +45,7 @@ return new class extends Migration {
         $date = '2023-07-13 00:00:00';
         $systemUserId = 'e144ff18-471f-456f-a1c2-971d88b3d213';
 
-        DB::table('dictionaries')->insertOrIgnore([
+        DB::table('dictionaries')->upsert([
             [
                 'id' => 'c21c1557-4617-42ae-ad20-12f8f89fb12b',
                 'name' => 'gender',
@@ -62,9 +62,9 @@ return new class extends Migration {
                 'created_at' => $date,
                 'updated_at' => $date,
             ],
-        ]);
+        ], 'id');
 
-        DB::table('positions')->insert([
+        DB::table('positions')->upsert([
             [
                 'id' => '1f3e095c-938b-4367-b3cc-7ef25ab1de70',
                 'dictionary_id' => 'c21c1557-4617-42ae-ad20-12f8f89fb12b',
@@ -265,7 +265,7 @@ return new class extends Migration {
                 'created_at' => $date,
                 'updated_at' => $date,
             ],
-        ]);
+        ], 'id');
     }
 
     /**

--- a/database/migrations/2023_11_01_150241_attributes_add_gender.php
+++ b/database/migrations/2023_11_01_150241_attributes_add_gender.php
@@ -6,8 +6,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     private string $genderAttributeId = '0e56d086-5bf7-46c0-8359-38e9edf8c627';
     private string $gender_column_name = 'gender_dict_id';
 
@@ -23,7 +22,7 @@ return new class extends Migration
         $genderDictionaryId = 'c21c1557-4617-42ae-ad20-12f8f89fb12b';
         $timestamp = CarbonImmutable::now();
         // Add row to attributes table
-        DB::table('attributes')->insertOrIgnore([
+        DB::table('attributes')->upsert([
             'id' => $this->genderAttributeId,
             'facility_id' => null,
             'table' => 'clients',
@@ -37,8 +36,7 @@ return new class extends Migration
             'requirement_level' => 'recommended',
             'created_at' => $timestamp,
             'updated_at' => $timestamp,
-        ]);
-
+        ], 'id');
     }
 
     /**

--- a/database/migrations/2023_11_01_150241_attributes_add_gender.php
+++ b/database/migrations/2023_11_01_150241_attributes_add_gender.php
@@ -20,7 +20,7 @@ return new class extends Migration {
         });
 
         $genderDictionaryId = 'c21c1557-4617-42ae-ad20-12f8f89fb12b';
-        $timestamp = CarbonImmutable::now();
+        $timestamp = '2023-11-01 00:00:00';
         // Add row to attributes table
         DB::table('attributes')->upsert([
             'id' => $this->genderAttributeId,

--- a/database/migrations/2023_11_02_183211_meeting_type.php
+++ b/database/migrations/2023_11_02_183211_meeting_type.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->down();
+
+        $date = '2023-11-02 00:00:00';
+        $systemUserId = 'e144ff18-471f-456f-a1c2-971d88b3d213';
+        DB::table('dictionaries')->upsert([
+            [
+                'id' => 'ce12aa23-a5db-49f3-987b-d2db3ab24a3b',
+                'name' => 'meetingCategory',
+                'is_fixed' => true,
+                'is_extendable' => true,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '4cc5d6b5-5913-4e07-9fcb-09b6f3d3d2a0',
+                'name' => 'meetingType',
+                'is_fixed' => true,
+                'is_extendable' => true,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+        ], 'id');
+
+        DB::table('positions')->upsert([
+            [
+                'id' => '137205e2-e9a1-4f8f-ada2-555319506b28',
+                'dictionary_id' => 'ce12aa23-a5db-49f3-987b-d2db3ab24a3b',
+                'name' => 'other',
+                'is_fixed' => true,
+                'is_disabled' => false,
+                'default_order' => 1,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+            [
+                'id' => '6e87acd5-70a0-4051-963b-42d439f44e42',
+                'dictionary_id' => '4cc5d6b5-5913-4e07-9fcb-09b6f3d3d2a0',
+                'name' => 'other',
+                'is_fixed' => true,
+                'is_disabled' => false,
+                'default_order' => 1,
+                'created_by' => $systemUserId,
+                'created_at' => $date,
+                'updated_at' => $date,
+            ],
+        ], 'id');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('positions')->where('dictionary_id', 'ce12aa23-a5db-49f3-987b-d2db3ab24a3b')->delete();
+        DB::table('dictionaries')->delete('ce12aa23-a5db-49f3-987b-d2db3ab24a3b');
+
+        DB::table('positions')->where('dictionary_id', '4cc5d6b5-5913-4e07-9fcb-09b6f3d3d2a0')->delete();
+        DB::table('dictionaries')->delete('4cc5d6b5-5913-4e07-9fcb-09b6f3d3d2a0');
+    }
+};

--- a/database/migrations/2023_11_02_183211_meeting_type.php
+++ b/database/migrations/2023_11_02_183211_meeting_type.php
@@ -11,8 +11,6 @@ return new class extends Migration {
      */
     public function up(): void
     {
-        $this->down();
-
         $date = '2023-11-02 00:00:00';
         $systemUserId = 'e144ff18-471f-456f-a1c2-971d88b3d213';
         DB::table('dictionaries')->upsert([

--- a/resources/lang/pl_PL/dictionary.yml
+++ b/resources/lang/pl_PL/dictionary.yml
@@ -7,3 +7,11 @@ gender:
   male: "mężczyzna"
   other: "inna"
   unknown: "nieznana"
+
+meetingCategory:
+  _name: "kategoria spotkania"
+  other: "inne"
+
+meetingType:
+  _name: "typ spotkania"
+  other: "inne"


### PR DESCRIPTION
zaproponowane przeze mnie ostatnio `insertOrIgnore` ignoruje wszystkie możliwe błędy, `upsert` robi bardziej to co potrzeba

zmieniłem daty w starych migracjach gdzie mi się rok pomylił (2022 :D), a zahardkodowałem

no i 2 nowe słowniki, tylko że typ i kategoria nie są połączone ze sobą, bedą połączone przez `attributes`