### PR TITLE
Refactoring in TQueryTable.

### DIFF
--- a/resources/js/components/ui/Table/TQueryTable.tsx
+++ b/resources/js/components/ui/Table/TQueryTable.tsx
@@ -74,9 +74,9 @@ export interface PartialColumnConfig {
   /** Additional columns from the tquery row that are used to construct the displayed value. */
   readonly extraDataColumns?: readonly ColumnName[];
   /**
-   * The TanStack column definition. If dataColumn is true, the tquery column is displayed by
+   * The TanStack column definition. If isDataColumn, the tquery column is displayed by
    * default. Otherwise, columnDef needs to be specified to display anything.
-   * Only dataColumn and extraDataColumns can be used in the columnDef.
+   * All additional data columns used in columnDef.cell needs to be specified in extraDataColumns.
    */
   readonly columnDef?: IdentifiedColumnDef<DataItem>;
   /** Some meta params for the column. They are merged into columnDef.meta.tquery (this is a shorthand). */
@@ -86,6 +86,8 @@ export interface PartialColumnConfig {
 }
 
 interface FullColumnConfig extends ColumnConfig {
+  /** Whether this column has a corresponding tquery column (with the same name) that it shows. */
+  readonly isDataColumn: boolean;
   readonly columnDef: IdentifiedColumnDef<DataItem>;
   readonly metaParams?: ColumnMetaParams;
 }

--- a/resources/js/components/ui/Table/TQueryTable.tsx
+++ b/resources/js/components/ui/Table/TQueryTable.tsx
@@ -1,16 +1,8 @@
-import {
-  ColumnDef,
-  IdentifiedColumnDef,
-  RowData,
-  SortingState,
-  createColumnHelper,
-  createSolidTable,
-} from "@tanstack/solid-table";
-import {NON_NULLABLE} from "components/utils";
+import {ColumnDef, IdentifiedColumnDef, RowData, SortingState, createSolidTable} from "@tanstack/solid-table";
 import {FilterH} from "data-access/memo-api/tquery/filter_utils";
-import {createTableRequestCreator, tableHelper} from "data-access/memo-api/tquery/table";
+import {ColumnConfig, createTableRequestCreator, tableHelper} from "data-access/memo-api/tquery/table";
 import {createTQuery} from "data-access/memo-api/tquery/tquery";
-import {ColumnType, DataItem, isDataType} from "data-access/memo-api/tquery/types";
+import {BasicColumnSchema, ColumnName, ColumnType, DataItem} from "data-access/memo-api/tquery/types";
 import {JSX, VoidComponent, createMemo} from "solid-js";
 import {
   DisplayMode,
@@ -29,29 +21,19 @@ import {
 } from ".";
 import {ColumnFilterController, FilteringParams} from "./tquery_filters/ColumnFilterController";
 
-export interface ColumnOptions {
-  columnDef?: Partial<IdentifiedColumnDef<DataItem>>;
-  metaParams?: ColumnMetaParams;
-}
-
-interface ColumnMetaParams {
-  canControlVisibility?: boolean;
-  filtering?: FilteringParams;
-}
-
 declare module "@tanstack/table-core" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
-    tquery?: TQueryColumnMeta;
+    readonly tquery?: TQueryColumnMeta;
   }
 }
 
-/** Type of tquery-related information in column meta. */
-export interface TQueryColumnMeta extends ColumnMetaParams {
-  /** Column type, if the column is based on data from backend. */
-  type?: ColumnType;
-  nullable?: boolean;
+export interface ColumnMetaParams {
+  readonly filtering?: FilteringParams;
 }
+
+/** Type of tquery-related information in column meta. */
+export interface TQueryColumnMeta extends ColumnMetaParams, Partial<BasicColumnSchema> {}
 
 export interface TQueryTableProps {
   /**
@@ -61,44 +43,69 @@ export interface TQueryTableProps {
    * - embedded - the table is displayed along with other elements in a page, typically with not
    * many rows, without sticky elements.
    */
-  mode: DisplayMode;
+  readonly mode: DisplayMode;
   /** The prefix used for the data query (this allows invalidating the tquery data). */
-  staticPrefixQueryKey: readonly unknown[];
+  readonly staticPrefixQueryKey: readonly unknown[];
   /** The entity URL, must not change. */
-  staticEntityURL: string;
-  staticTranslations?: TableTranslations;
+  readonly staticEntityURL: string;
+  readonly staticTranslations?: TableTranslations;
   /**
    * The filter that is always applied to the data, regardless of other filtering.
    * This is used to create e.g. a table of entities A on the details page of a particular
    * entity B, so only entities A related direclty to that particular entity B should be shown.
    */
-  intrinsicFilter?: FilterH;
-  /**
-   * A list of columns that are always included in the request (and available on the row objects),
-   * even if they are not visible.
-   */
-  intrinsicColumns?: readonly string[];
-  /** Additional column names. Their options are taken from `columnOptions`. */
-  additionalColumns?: readonly string[];
-  /** Overrides for the definition of specific columns. */
-  columnOptions?: Readonly<Partial<Record<string, ColumnOptions>>>;
-  /**
-   * The ordering of the columns. All the columns present on the backend and not present
-   * in this list are placed at the end.
-   *
-   * This list can be used to sort both data-based columns and additional columns
-   * (declared in additionalColumns).
-   *
-   * In the current implementation the order of columns cannot be changed.
-   */
-  initialColumnsOrder?: readonly string[];
-  initialVisibleColumns?: readonly string[];
-  initialSort?: SortingState;
-  initialPageSize?: number;
-  /** These columns are ignored and never shown. */
-  ignoreColumns?: readonly string[];
+  readonly intrinsicFilter?: FilterH;
+  /** The definition of the columns in the table, in their correct order. */
+  readonly columns: readonly PartialColumnConfig[];
+  readonly initialSort?: SortingState;
+  readonly initialPageSize?: number;
   /** Element to put below table, after the summary. */
-  customSectionBelowTable?: JSX.Element;
+  readonly customSectionBelowTable?: JSX.Element;
+}
+
+export interface PartialColumnConfig {
+  /** The name (id) of the column. */
+  readonly name: string;
+  /**
+   * Whether this column has a corresponding tquery column (with the same name) that it shows.
+   * Default: true.
+   */
+  readonly isDataColumn?: boolean;
+  /** Additional columns from the tquery row that are used to construct the displayed value. */
+  readonly extraDataColumns?: readonly ColumnName[];
+  /**
+   * The TanStack column definition. If dataColumn is true, the tquery column is displayed by
+   * default. Otherwise, columnDef needs to be specified to display anything.
+   * Only dataColumn and extraDataColumns can be used in the columnDef.
+   */
+  readonly columnDef?: IdentifiedColumnDef<DataItem>;
+  /** Some meta params for the column. They are merged into columnDef.meta.tquery (this is a shorthand). */
+  readonly metaParams?: ColumnMetaParams;
+  /** The initial column visibility. Default: true. */
+  readonly initialVisible?: boolean;
+}
+
+interface FullColumnConfig extends ColumnConfig {
+  readonly columnDef: IdentifiedColumnDef<DataItem>;
+  readonly metaParams?: ColumnMetaParams;
+}
+
+function columnConfigFromPartial({
+  name,
+  isDataColumn = true,
+  extraDataColumns = [],
+  columnDef = {},
+  metaParams,
+  initialVisible = true,
+}: PartialColumnConfig): FullColumnConfig {
+  return {
+    name,
+    isDataColumn,
+    dataColumns: isDataColumn ? [name, ...extraDataColumns] : extraDataColumns,
+    columnDef,
+    metaParams,
+    initialVisible,
+  };
 }
 
 const DEFAULT_STANDALONE_PAGE_SIZE = 50;
@@ -106,6 +113,7 @@ const DEFAULT_EMBEDDED_PAGE_SIZE = 10;
 
 export const TQueryTable: VoidComponent<TQueryTableProps> = (props) => {
   const entityURL = props.staticEntityURL;
+  const columnsConfig = createMemo(() => props.columns.map((col) => columnConfigFromPartial(col)));
 
   const tableCells = useTableCells();
   const columnDefByType = new Map<ColumnType, Partial<IdentifiedColumnDef<DataItem>>>([
@@ -119,10 +127,8 @@ export const TQueryTable: VoidComponent<TQueryTableProps> = (props) => {
   ]);
 
   const requestCreator = createTableRequestCreator({
+    columnsConfig,
     intrinsicFilter: () => props.intrinsicFilter,
-    intrinsicColumns: () => props.intrinsicColumns,
-    additionalColumns: props.additionalColumns,
-    initialVisibleColumns: props.initialVisibleColumns,
     initialSort: props.initialSort,
     initialPageSize:
       props.initialPageSize ||
@@ -139,98 +145,56 @@ export const TQueryTable: VoidComponent<TQueryTableProps> = (props) => {
     response: () => dataQuery.data,
   });
 
-  const h = createColumnHelper<DataItem>();
-  function columnOptions(name: string) {
-    return props.columnOptions?.[name] || {};
-  }
-  function commonColumnDef(name: string, type?: ColumnType) {
-    return {
-      id: name,
-      // Default accessor in tanstack supports nested properties (e.g. "a.b" looking for {a: {b: ...}}), but we have
-      // flat fields with dots in the names, e.g. { 'createdBy.name': ... }.
-      accessorFn: (originalRow: DataItem) => originalRow[name],
-      header: (ctx) => (
-        <Header
-          ctx={ctx}
-          filter={
-            <ColumnFilterController
-              name={ctx.column.id}
-              filter={columnFilter(ctx.column.id)[0]()}
-              setFilter={(filter) => columnFilter(ctx.column.id)[1](filter)}
-            />
-          }
-        />
-      ),
-      ...(type && columnDefByType.get(type)),
-      ...columnOptions(name).columnDef,
-    } satisfies Partial<ColumnDef<DataItem>>;
-  }
   const columns = createMemo(() => {
     const sch = schema();
     if (!sch) return [];
-
-    const badColumns = new Set([
-      ...Object.keys(props.columnOptions || {}),
-      ...(props.initialColumnsOrder || []),
-      ...(props.initialVisibleColumns || []),
-      ...(props.ignoreColumns || []),
-    ]);
-    for (const {name} of sch.columns) {
-      badColumns.delete(name);
-    }
-    for (const name of props.additionalColumns || []) {
-      badColumns.delete(name);
-    }
-    if (badColumns.size)
-      console.error(`Some columns are configured but not present in the columns list: ` + [...badColumns].join(", "));
-
-    const ignoreColumnsSet = new Set(props.ignoreColumns || []);
-    const schemaColumns = sch.columns.filter(({name}) => !ignoreColumnsSet.has(name));
-    const columns = [
-      ...schemaColumns
-        .map(({type, nullable, name}) => {
-          if (!isDataType(type)) {
-            return undefined;
-          }
-          const common = commonColumnDef(name, type);
-          return h.accessor(name, {
-            ...common,
-            meta: {
-              ...common.meta,
-              tquery: {
-                type,
-                nullable,
-                ...columnOptions(name).metaParams,
-              } satisfies TQueryColumnMeta,
-            },
-          });
-        })
-        .filter(NON_NULLABLE),
-      ...(props.additionalColumns || []).map((name) => {
-        const common = commonColumnDef(name);
-        return h.display({
-          ...common,
-          meta: {
-            ...common.meta,
-            tquery: {
-              ...columnOptions(name).metaParams,
-            },
-          },
-        });
-      }),
-    ];
-    if (props.initialColumnsOrder) {
-      // Index in the ordering array. Missing items sorted last.
-      const order = (col: ColumnDef<DataItem, unknown>) => (props.initialColumnsOrder!.indexOf(col.id!) + 1e6) % 1e6;
-      columns.sort((a, b) => order(a) - order(b));
-    }
-    return columns;
+    return columnsConfig().map((col) => {
+      let schemaCol = undefined;
+      if (col.isDataColumn) {
+        schemaCol = sch.columns.find(({name}) => name === col.name);
+        if (!schemaCol) {
+          throw new Error(`Column ${col.name} not found in schema`);
+        }
+        if (schemaCol.type === "count") {
+          throw new Error(`Column ${col.name} is a count column`);
+        }
+      }
+      return {
+        id: col.name,
+        accessorFn: col.isDataColumn ? (originalRow) => originalRow[col.name] : undefined,
+        header: (ctx) => (
+          <Header
+            ctx={ctx}
+            filter={
+              <ColumnFilterController
+                name={ctx.column.id}
+                filter={columnFilter(ctx.column.id)[0]()}
+                setFilter={(filter) => columnFilter(ctx.column.id)[1](filter)}
+              />
+            }
+          />
+        ),
+        ...(schemaCol?.type && columnDefByType.get(schemaCol.type)),
+        // It would be ideal to restrict the cell function to only accessing the data columns declared
+        // by the column config, but there is no easy way to do this. The whole row is a store and cannot
+        // be mutated, and wrapping it would be complicated.
+        ...col.columnDef,
+        meta: {
+          ...col.columnDef.meta,
+          tquery: {
+            ...schemaCol,
+            ...col.metaParams,
+          } satisfies TQueryColumnMeta,
+        },
+      } satisfies ColumnDef<DataItem, unknown>;
+    });
   });
 
   const table = createSolidTable<DataItem>({
     ...getBaseTableOptions<DataItem>({features: {columnVisibility, sorting, globalFilter, pagination}}),
     get data() {
-      return data();
+      // Remove readonly from the type.
+      return data() as DataItem[];
     },
     get columns() {
       return columns();

--- a/resources/js/components/ui/Table/TableColumnVisibilityController.tsx
+++ b/resources/js/components/ui/Table/TableColumnVisibilityController.tsx
@@ -37,7 +37,7 @@ export const TableColumnVisibilityController: VoidComponent = () => {
             <div class="bg-white border border-gray-700 rounded flex flex-col overflow-clip">
               <For each={table.getAllLeafColumns()}>
                 {(column) => (
-                  <Show when={column.columnDef.meta?.tquery?.canControlVisibility !== false}>
+                  <Show when={column.getCanHide()}>
                     <label
                       class={cx("px-2 pt-0.5 hover:bg-hover flex gap-1 items-baseline", {
                         "!bg-select": column.getIsVisible(),

--- a/resources/js/components/ui/Table/tquery_filters/ColumnFilterController.tsx
+++ b/resources/js/components/ui/Table/tquery_filters/ColumnFilterController.tsx
@@ -9,11 +9,11 @@ import {UuidFilterControl} from "./UuidFilterControl";
 import {FilterControlProps} from "./types";
 
 interface CommonFilteringParams {
-  enabled?: boolean;
+  readonly enabled?: boolean;
 }
 
 export interface DateTimeFilteringParams extends CommonFilteringParams {
-  useDateTimeInputs?: boolean;
+  readonly useDateTimeInputs?: boolean;
 }
 
 export type FilteringParams = DateTimeFilteringParams;

--- a/resources/js/data-access/memo-api/tquery/filter_utils.ts
+++ b/resources/js/data-access/memo-api/tquery/filter_utils.ts
@@ -8,7 +8,7 @@ import {BoolOpFilter, ColumnFilter, ColumnName, ColumnSchema, ConstFilter, Filte
  */
 export type FilterH = ConstFilter | Filter | BoolOpFilterH;
 /** A bool operation filter that accepts FilterH as sub-filters. */
-export type BoolOpFilterH = Omit<BoolOpFilter, "val"> & {readonly val: FilterH[]};
+export type BoolOpFilterH = Omit<BoolOpFilter, "val"> & {readonly val: readonly FilterH[]};
 
 /** A reduced filter. It is a regular, fully correct and at least somewhat optimised filter. */
 export type ReducedFilterH = ConstFilter | Filter;

--- a/resources/js/data-access/memo-api/tquery/table.ts
+++ b/resources/js/data-access/memo-api/tquery/table.ts
@@ -8,8 +8,6 @@ import {Column, ColumnName, DataRequest, DataResponse} from "./types";
 
 export interface ColumnConfig {
   readonly name: string;
-  /** Whether this column has a corresponding tquery column (with the same name) that it shows. */
-  readonly isDataColumn: boolean;
   /** A list of tquery columns needed to construct this column. */
   readonly dataColumns: readonly ColumnName[];
   readonly initialVisible: boolean;

--- a/resources/js/data-access/memo-api/tquery/tquery.ts
+++ b/resources/js/data-access/memo-api/tquery/tquery.ts
@@ -18,7 +18,7 @@ function getRequestFromQueryKey<K extends PrefixQueryKey>(queryKey: DataQueryKey
 
 const INITIAL_PAGE_SIZE = 50;
 
-const EMPTY_DATA: DataItem[] = [];
+const EMPTY_DATA: readonly DataItem[] = [];
 
 /** A utility that creates and helps with managing the request object. */
 export interface RequestCreator<C> {

--- a/resources/js/data-access/memo-api/tquery/types.ts
+++ b/resources/js/data-access/memo-api/tquery/types.ts
@@ -12,7 +12,7 @@ export type DateTimeString = string;
 type Mapping<Key extends string, Value> = Readonly<Partial<Record<Key, Value>>>;
 
 export interface Schema {
-  readonly columns: ColumnSchema[];
+  readonly columns: readonly ColumnSchema[];
   readonly customFilters?: Mapping<CustomFilterName, CustomFilter>;
 }
 
@@ -44,7 +44,7 @@ export interface CustomFilter {
 }
 
 export interface DataRequest {
-  readonly columns: Column[];
+  readonly columns: readonly Column[];
   readonly filter?: ConstFilter | Filter;
   readonly sort: Sort;
   readonly paging: Paging;
@@ -79,7 +79,7 @@ export interface BoolOpFilter extends FilterBase {
   readonly type: "op";
   readonly op: "&" | "|";
   /** List of sub-filters. Cannot be empty. */
-  readonly val: Filter[];
+  readonly val: readonly Filter[];
 }
 
 export type ColumnFilter = NullColumnFilter | ColumnValueFilter;
@@ -115,7 +115,7 @@ interface BinEqColumnFilter<T> extends ColumnFilterBase {
 interface InColumnFilter<T> extends ColumnFilterBase {
   readonly op: "in";
   /** The values to compare to. Cannot contain an empty string. */
-  readonly val: T[];
+  readonly val: readonly T[];
 }
 interface CmpColumnFilter<T> extends ColumnFilterBase {
   readonly op: ">" | "<" | ">=" | "<=";
@@ -175,7 +175,7 @@ export interface Paging {
 
 export interface DataResponse {
   readonly meta: DataResponseMeta;
-  readonly data: DataItem[];
+  readonly data: readonly DataItem[];
 }
 
 export interface DataResponseMeta {
@@ -186,7 +186,7 @@ export interface DataResponseMeta {
 export type DataItem = Mapping<ColumnName, unknown>;
 
 /** Specification of the data sorting. The first element has the highest priority. */
-export type Sort = SortItem[];
+export type Sort = readonly SortItem[];
 
 export type SortItem = SortColumn;
 

--- a/resources/js/features/root/pages/AdminFacilitiesList.page.tsx
+++ b/resources/js/features/root/pages/AdminFacilitiesList.page.tsx
@@ -1,5 +1,5 @@
 import {Button} from "components/ui/Button";
-import {AUTO_SIZE_COLUMN_DEFS, createTableTranslations} from "components/ui/Table";
+import {AUTO_SIZE_COLUMN_DEFS, cellFunc, createTableTranslations} from "components/ui/Table";
 import {TQueryTable} from "components/ui/Table/TQueryTable";
 import {useLangFunc} from "components/utils";
 import {Admin} from "data-access/memo-api/groups/Admin";
@@ -18,31 +18,16 @@ export default (() => {
         staticPrefixQueryKey={Admin.keys.facility()}
         staticEntityURL="admin/facility"
         staticTranslations={createTableTranslations("facilities")}
-        intrinsicColumns={["id"]}
-        initialColumnsOrder={["id", "name", "url", "createdAt", "updatedAt"]}
-        initialVisibleColumns={["name", "url", "createdAt", "actions"]}
-        initialSort={[{id: "name", desc: false}]}
-        additionalColumns={["actions"]}
-        columnOptions={{
-          name: {
-            metaParams: {canControlVisibility: false},
-          },
-          url: {
-            columnDef: {
-              cell: (c) => `/${c.getValue()}`,
-            },
-          },
-          createdAt: {
-            columnDef: {
-              sortDescFirst: true,
-            },
-          },
-          updatedAt: {
-            columnDef: {
-              sortDescFirst: true,
-            },
-          },
-          actions: {
+        columns={[
+          {name: "id", initialVisible: false},
+          {name: "name", columnDef: {enableHiding: false}},
+          {name: "url", columnDef: {cell: cellFunc<string>((url) => `/${url}`)}},
+          {name: "createdAt", columnDef: {sortDescFirst: true}},
+          {name: "updatedAt", columnDef: {sortDescFirst: true}, initialVisible: false},
+          {
+            name: "actions",
+            isDataColumn: false,
+            extraDataColumns: ["id"],
             columnDef: {
               cell: (c) => (
                 <Button onClick={() => showFacilityEditModal({facilityId: c.row.getValue("id")})}>
@@ -53,7 +38,8 @@ export default (() => {
               ...AUTO_SIZE_COLUMN_DEFS,
             },
           },
-        }}
+        ]}
+        initialSort={[{id: "name", desc: false}]}
         customSectionBelowTable={
           <div class="ml-2 flex gap-1">
             <Button class="secondarySmall" onClick={() => showFacilityCreateModal()}>

--- a/resources/js/features/root/pages/AdminUsersList.page.tsx
+++ b/resources/js/features/root/pages/AdminUsersList.page.tsx
@@ -19,35 +19,28 @@ export default (() => {
         staticPrefixQueryKey={Admin.keys.user()}
         staticEntityURL="admin/user"
         staticTranslations={createTableTranslations("users")}
-        intrinsicColumns={["id"]}
-        additionalColumns={["actions"]}
-        ignoreColumns={["lastLoginFacility.id", "lastLoginFacility.name", "createdBy.id"]}
-        columnOptions={{
-          name: {
-            metaParams: {canControlVisibility: false},
-          },
-          email: {
+        columns={[
+          {name: "id", initialVisible: false},
+          {name: "name", columnDef: {enableHiding: false}},
+          {name: "email", columnDef: {cell: cellFunc<string>((v) => <Email class="w-full" email={v} />)}},
+          {name: "hasEmailVerified", initialVisible: false},
+          {name: "hasPassword"},
+          {name: "passwordExpireAt", initialVisible: false},
+          {name: "facilityCount", initialVisible: false},
+          {
+            name: "hasGlobalAdmin",
             columnDef: {
-              cell: cellFunc<string>((v) => <Email class="w-full" email={v} />),
-            },
-          },
-          createdAt: {
-            columnDef: {
-              sortDescFirst: true,
-            },
-          },
-          updatedAt: {
-            columnDef: {
-              sortDescFirst: true,
-            },
-          },
-          hasGlobalAdmin: {
-            columnDef: {
-              cell: (c) => <span class="w-full text-center">{c.getValue() ? "💪🏽" : ""}</span>,
+              cell: cellFunc<boolean>((adm) => <span class="w-full text-center">{adm ? "💪🏽" : ""}</span>),
               size: 130,
             },
           },
-          actions: {
+          {name: "createdAt", columnDef: {sortDescFirst: true}},
+          {name: "createdBy.name", initialVisible: false},
+          {name: "updatedAt", columnDef: {sortDescFirst: true}, initialVisible: false},
+          {
+            name: "actions",
+            isDataColumn: false,
+            extraDataColumns: ["id"],
             columnDef: {
               cell: (c) => (
                 <Button onClick={() => UserEditForm.showModalFor({userId: c.row.getValue("id")})}>
@@ -58,22 +51,7 @@ export default (() => {
               ...AUTO_SIZE_COLUMN_DEFS,
             },
           },
-        }}
-        initialColumnsOrder={[
-          "id",
-          "name",
-          "email",
-          "hasEmailVerified",
-          "hasPassword",
-          "passwordExpireAt",
-          "facilityCount",
-          "hasGlobalAdmin",
-          "createdAt",
-          "createdBy.name",
-          "updatedAt",
-          "actions",
         ]}
-        initialVisibleColumns={["name", "email", "hasPassword", "createdAt", "hasGlobalAdmin", "actions"]}
         initialSort={[{id: "name", desc: false}]}
         customSectionBelowTable={
           <div class="ml-2 flex gap-1">


### PR DESCRIPTION
Simplified configuring the columns, which also simplified the implementation.
Now each column needs to be explicitly configured in the table to be accessible.