### PR TITLE
Multiple improvements on the calendar page:

### DIFF
--- a/resources/js/components/ui/calendar/calendar-columns/events.module.scss
+++ b/resources/js/components/ui/calendar/calendar-columns/events.module.scss
@@ -1,0 +1,17 @@
+.blink {
+  animation-duration: 230ms;
+  animation-name: blink;
+  animation-iteration-count: 6;
+  animation-direction: alternate;
+  animation-timing-function: ease-in-out;
+
+  @apply outline outline-4 outline-transparent;
+  outline-offset: -4px;
+}
+
+@keyframes blink {
+  to {
+    @apply opacity-60 outline-memo-active;
+    outline-offset: -6px;
+  }
+}

--- a/resources/js/components/ui/calendar/calendar-columns/events.tsx
+++ b/resources/js/components/ui/calendar/calendar-columns/events.tsx
@@ -14,6 +14,7 @@ import {MeetingDateAndTimeInfo} from "features/meeting/DateAndTimeInfo";
 import {For, JSX, ParentComponent, Show, VoidComponent, createMemo, createSignal, createUniqueId} from "solid-js";
 import {Portal} from "solid-js/web";
 import {useColumnsCalendar} from "../ColumnsCalendar";
+import s from "./events.module.scss";
 
 interface AllDayEventProps {
   readonly baseColor: string;
@@ -34,7 +35,12 @@ export const AllDayEventBlock: ParentComponent<AllDayEventProps> = (props) => (
 interface MeetingEventProps {
   readonly meeting: TQMeetingResource;
   readonly style?: JSX.CSSProperties;
+  /** Whether the event block should blink initially to call the user's attention. */
+  readonly blink?: boolean;
   readonly hoverStyle?: JSX.CSSProperties;
+  readonly onHoverChange?: (hovered: boolean) => void;
+  /** Whether the hovered style should be used. If not provided, the real element hover state is used. */
+  readonly hovered?: boolean;
   readonly onClick?: () => void;
 }
 
@@ -91,11 +97,19 @@ export const MeetingEventBlock: VoidComponent<MeetingEventProps> = (props) => {
     {context: () => ({openDelay: dictionaries() ? 100 : 2000})},
   );
   const hoverApi = createMemo(() => hoverCard.connect(hoverState, hoverSend, normalizeProps));
-  const [hovered, setHovered] = createSignal(false);
+  const [hoveredGetter, hoveredSetter] = createSignal(false);
+  function setHovered(hovered: boolean) {
+    hoveredSetter(hovered);
+    props.onHoverChange?.(hovered);
+  }
+  const hovered = () => props.hovered ?? hoveredGetter();
   return (
     <>
       <div
-        class="w-full h-full border rounded px-0.5 overflow-clip flex flex-col items-stretch cursor-pointer select-none"
+        class={cx(
+          "w-full h-full border rounded px-0.5 overflow-clip flex flex-col items-stretch cursor-pointer select-none",
+          {[s.blink!]: props.blink},
+        )}
         style={{...props.style, ...(hovered() ? props.hoverStyle : undefined)}}
         {...hoverApi().triggerProps}
         onMouseEnter={[setHovered, true]}

--- a/resources/js/data-access/memo-api/resources/meeting.resource.ts
+++ b/resources/js/data-access/memo-api/resources/meeting.resource.ts
@@ -18,6 +18,7 @@ export interface MeetingResource {
   readonly staff: readonly MeetingAttendantResource[];
   readonly clients: readonly MeetingAttendantResource[];
   readonly resources: readonly MeetingResourceResource[];
+  readonly fromMeetingId: string | null;
 }
 
 export interface MeetingAttendantResource {
@@ -31,7 +32,18 @@ export interface MeetingResourceResource {
 
 export type MeetingResourceForCreate = Pick<
   MeetingResource,
-  "typeDictId" | "notes" | "isRemote" | "staff" | "clients" | "resources"
+  | "typeDictId"
+  | "notes"
+  // See below for why these are not included.
+  // | "date"
+  // | "startDayminute"
+  // | "durationMinutes"
+  | "statusDictId"
+  | "isRemote"
+  | "staff"
+  | "clients"
+  | "resources"
+  | "fromMeetingId"
 > &
   // This part is actually required by the API, but has no default values, so making it optional
   // is necessary to construct a create form.

--- a/resources/js/features/meeting/MeetingAttendantsFields.tsx
+++ b/resources/js/features/meeting/MeetingAttendantsFields.tsx
@@ -214,14 +214,14 @@ function createAttendant({userId = "", attendanceStatusDictId}: Partial<MeetingA
   return {userId, attendanceStatusDictId: attendanceStatusDictId || ""} satisfies MeetingAttendantResource;
 }
 
-export function getInitialAttendantsForCreate(staff?: readonly string[]) {
+export function attendantsInitialValueForCreate(staff?: readonly string[]) {
   return {
     staff: staff?.map((userId) => createAttendant({userId})) || [],
     clients: [],
   } satisfies FormAttendantsData;
 }
 
-export function getInitialAttendantsForEdit(meeting: MeetingResource) {
+export function attendantsInitialValueForEdit(meeting: MeetingResource) {
   function getAttendants(attendantsFromMeeting: readonly MeetingAttendantResource[]) {
     const attendants = attendantsFromMeeting.map(createAttendant);
     if (attendants.length > 1) {

--- a/resources/js/features/meeting/MeetingViewEditForm.tsx
+++ b/resources/js/features/meeting/MeetingViewEditForm.tsx
@@ -1,6 +1,10 @@
 import {createMutation, createQuery} from "@tanstack/solid-query";
-import {BigSpinner} from "components/ui/Spinner";
+import {Button, EditButton} from "components/ui/Button";
+import {MenuItem, SimpleMenu} from "components/ui/SimpleMenu";
+import {BigSpinner, SmallSpinner} from "components/ui/Spinner";
+import {SplitButton} from "components/ui/SplitButton";
 import {createConfirmation} from "components/ui/confirmation";
+import {ACTION_ICONS} from "components/ui/icons";
 import {QueryBarrier, useLangFunc} from "components/utils";
 import {notFoundError} from "components/utils/NotFoundError";
 import {dayMinuteToTimeInput} from "components/utils/day_minute_util";
@@ -8,11 +12,16 @@ import {useAttributes} from "data-access/memo-api/attributes";
 import {useDictionaries} from "data-access/memo-api/dictionaries";
 import {FacilityMeeting} from "data-access/memo-api/groups/FacilityMeeting";
 import {useInvalidator} from "data-access/memo-api/invalidator";
+import {MeetingResource} from "data-access/memo-api/resources/meeting.resource";
 import {Api} from "data-access/memo-api/types";
+import {DateTime} from "luxon";
+import {FaRegularCalendarPlus} from "solid-icons/fa";
 import {Show, VoidComponent} from "solid-js";
 import toast from "solid-toast";
-import {getInitialAttendantsForEdit} from "./MeetingAttendantsFields";
+import {attendantsInitialValueForEdit} from "./MeetingAttendantsFields";
 import {MeetingForm, MeetingFormType, transformFormValues} from "./MeetingForm";
+import {MeetingChangeSuccessData} from "./meeting_change_success_data";
+import {createMeetingCreateModal} from "./meeting_create_modal";
 
 interface FormParams {
   readonly id: Api.Id;
@@ -21,9 +30,12 @@ interface FormParams {
 interface Props extends FormParams {
   readonly viewMode?: boolean;
   readonly onViewModeChange?: (viewMode: boolean) => void;
-  readonly onEdited?: () => void;
-  readonly onDeleted?: () => void;
+  readonly onEdited?: (meeting: MeetingChangeSuccessData) => void;
+  readonly onCopyCreated?: (meeting: MeetingChangeSuccessData) => void;
+  readonly onDeleted?: (meetingId: string) => void;
   readonly onCancel?: () => void;
+  /** Whether to show toast on success. Default: true. */
+  readonly showToast?: boolean;
 }
 
 export const MeetingViewEditForm: VoidComponent<Props> = (props) => {
@@ -31,8 +43,10 @@ export const MeetingViewEditForm: VoidComponent<Props> = (props) => {
   const attributes = useAttributes();
   const dictionaries = useDictionaries();
   const invalidate = useInvalidator();
+  const meetingCreateModal = createMeetingCreateModal();
   const confirmation = createConfirmation();
   const meetingQuery = createQuery(() => FacilityMeeting.meetingQueryOptions(props.id));
+  const meeting = () => meetingQuery.data!;
   const meetingMutation = createMutation(() => ({
     mutationFn: FacilityMeeting.updateMeeting,
     meta: {isFormSubmit: true},
@@ -40,14 +54,18 @@ export const MeetingViewEditForm: VoidComponent<Props> = (props) => {
   const deleteMeetingMutation = createMutation(() => ({
     mutationFn: FacilityMeeting.deleteMeeting,
   }));
+  const isDeleting = () => deleteMeetingMutation.isPending;
 
   async function updateMeeting(values: MeetingFormType) {
-    await meetingMutation.mutateAsync({
+    const meeting = {
       id: props.id,
       ...transformFormValues(values),
-    });
-    toast.success(t("forms.meeting_edit.success"));
-    props.onEdited?.();
+    };
+    await meetingMutation.mutateAsync(meeting);
+    if (props.showToast ?? true) {
+      toast.success(t("forms.meeting_edit.success"));
+    }
+    props.onEdited?.(meeting as MeetingResource);
     // Important: Invalidation should happen after calling onEdited which typically closes the form.
     // Otherwise the queries used by this form start fetching data immediately, which not only makes no sense,
     // but also causes problems apparently.
@@ -64,8 +82,10 @@ export const MeetingViewEditForm: VoidComponent<Props> = (props) => {
     )
       return;
     await deleteMeetingMutation.mutateAsync(props.id);
-    toast.success(t("forms.meeting_delete.success"));
-    props.onDeleted?.();
+    if (props.showToast ?? true) {
+      toast.success(t("forms.meeting_delete.success"));
+    }
+    props.onDeleted?.(props.id);
     // Important: Invalidation should happen after calling onDeleted which typically closes the form.
     // Otherwise the queries used by this form start fetching data immediately, which not only makes no sense,
     // but also causes problems apparently.
@@ -73,34 +93,106 @@ export const MeetingViewEditForm: VoidComponent<Props> = (props) => {
   }
 
   const initialValues = () => {
-    const meeting = meetingQuery.data;
-    return meeting
-      ? ({
-          ...meeting,
-          time: {
-            startTime: dayMinuteToTimeInput(meeting.startDayminute),
-            endTime: dayMinuteToTimeInput(meeting.startDayminute + meeting.durationMinutes),
-          },
-          ...getInitialAttendantsForEdit(meeting),
-          notes: meeting.notes || "",
-          resources: meeting.resources.map(({resourceDictId}) => resourceDictId),
-        } satisfies MeetingFormType)
-      : {};
+    return {
+      date: meeting().date,
+      time: {
+        startTime: dayMinuteToTimeInput(meeting().startDayminute),
+        endTime: dayMinuteToTimeInput(meeting().startDayminute + meeting().durationMinutes),
+      },
+      typeDictId: meeting().typeDictId,
+      statusDictId: meeting().statusDictId,
+      ...attendantsInitialValueForEdit(meeting()),
+      isRemote: meeting().isRemote,
+      notes: meeting().notes || "",
+      resources: meeting().resources.map(({resourceDictId}) => resourceDictId),
+      fromMeetingId: meeting().fromMeetingId || "",
+    } satisfies MeetingFormType;
   };
+
+  function createCopyInDays(days: number) {
+    meetingCreateModal.show({
+      initialValues: {
+        ...initialValues(),
+        date: DateTime.fromISO(meeting().date).plus({days}).toISODate(),
+        fromMeetingId: props.id,
+      },
+      onSuccess: props.onCopyCreated,
+      showToast: props.showToast,
+    });
+  }
 
   return (
     <QueryBarrier queries={[meetingQuery]} ignoreCachedData {...notFoundError()}>
       <Show when={attributes() && dictionaries()} fallback={<BigSpinner />}>
-        <MeetingForm
-          id="meeting_edit"
-          initialValues={initialValues()}
-          viewMode={props.viewMode}
-          onViewModeChange={props.onViewModeChange}
-          onSubmit={updateMeeting}
-          onDelete={deleteMeeting}
-          isDeleting={deleteMeetingMutation.isPending}
-          onCancel={props.onCancel}
-        />
+        <div class="flex flex-col gap-3">
+          <MeetingForm
+            id="meeting_edit"
+            initialValues={initialValues()}
+            viewMode={props.viewMode}
+            onSubmit={updateMeeting}
+            onCancel={() => {
+              if (props.onViewModeChange) {
+                props.onViewModeChange(true);
+              } else {
+                props.onCancel?.();
+              }
+            }}
+          />
+          <Show when={props.viewMode && props.onViewModeChange}>
+            <div class="flex gap-1 justify-between">
+              <Button class="secondary small" onClick={deleteMeeting} disabled={isDeleting()}>
+                <ACTION_ICONS.delete class="inlineIcon text-current" />
+                {t("actions.delete")}
+                <Show when={isDeleting()}>
+                  <SmallSpinner />
+                </Show>
+              </Button>
+              <div class="flex gap-1">
+                <SplitButton
+                  class="secondary small"
+                  onClick={[createCopyInDays, 0]}
+                  popOver={(popOver) => {
+                    function createItem(labelKey: string, days: number): MenuItem {
+                      return {
+                        label: (
+                          <div class="flex justify-between gap-2">
+                            <span>{t(`calendar.relative_time.${labelKey}`)}</span>
+                            <span class="text-grey-text">
+                              {t("parenthesised", {
+                                text: DateTime.fromISO(meeting().date)
+                                  .plus({days})
+                                  .toLocaleString({day: "numeric", month: "long"}),
+                              })}
+                            </span>
+                          </div>
+                        ),
+                        onClick: [createCopyInDays, days],
+                      };
+                    }
+                    return (
+                      <SimpleMenu
+                        items={[
+                          createItem("in_one_day", 1),
+                          createItem("in_one_week", 7),
+                          createItem("in_two_weeks", 14),
+                        ]}
+                        onClick={() => popOver().close()}
+                      />
+                    );
+                  }}
+                  disabled={isDeleting()}
+                >
+                  <FaRegularCalendarPlus class="inlineIcon text-current" /> {t("actions.meeting.make_a_copy")}
+                </SplitButton>
+                <EditButton
+                  class="secondary small"
+                  onClick={[props.onViewModeChange!, false]}
+                  disabled={isDeleting()}
+                />
+              </div>
+            </div>
+          </Show>
+        </div>
       </Show>
     </QueryBarrier>
   );

--- a/resources/js/features/meeting/meeting_change_success_data.ts
+++ b/resources/js/features/meeting/meeting_change_success_data.ts
@@ -1,0 +1,7 @@
+import {MeetingResource} from "data-access/memo-api/resources/meeting.resource";
+
+/** Data associated with a successful API call of creating or editing a meeting. */
+export type MeetingChangeSuccessData = Pick<
+  MeetingResource,
+  "id" | "date" | "startDayminute" | "durationMinutes" | "staff" | "clients" | "resources"
+>;

--- a/resources/js/features/meeting/meeting_create_modal.tsx
+++ b/resources/js/features/meeting/meeting_create_modal.tsx
@@ -1,13 +1,17 @@
 import {MODAL_STYLE_PRESETS, Modal} from "components/ui/Modal";
 import {useLangFunc} from "components/utils";
 import {registerGlobalPageElement} from "components/utils/GlobalPageElements";
-import {InitialDataParams} from "features/meeting/MeetingCreateForm";
 import {lazy} from "solid-js";
+import {MeetingFormType} from "./MeetingForm";
+import {MeetingChangeSuccessData} from "./meeting_change_success_data";
 
 const MeetingCreateForm = lazy(() => import("features/meeting/MeetingCreateForm"));
 
 interface FormParams {
-  readonly initialData?: InitialDataParams;
+  readonly initialValues?: Partial<MeetingFormType>;
+  readonly onSuccess?: (meeting: MeetingChangeSuccessData) => void;
+  /** Whether to show toast on success. Default: true. */
+  readonly showToast?: boolean;
 }
 
 export const createMeetingCreateModal = registerGlobalPageElement<FormParams>((args) => {
@@ -22,9 +26,13 @@ export const createMeetingCreateModal = registerGlobalPageElement<FormParams>((a
     >
       {(params) => (
         <MeetingCreateForm
-          initialData={params().initialData}
-          onSuccess={args.clearParams}
+          initialValues={params().initialValues}
+          onSuccess={(meeting) => {
+            params().onSuccess?.(meeting);
+            args.clearParams();
+          }}
           onCancel={args.clearParams}
+          showToast={params().showToast}
         />
       )}
     </Modal>

--- a/resources/js/features/meeting/meeting_modal.tsx
+++ b/resources/js/features/meeting/meeting_modal.tsx
@@ -4,6 +4,7 @@ import {useLangFunc} from "components/utils";
 import {registerGlobalPageElement} from "components/utils/GlobalPageElements";
 import {Api} from "data-access/memo-api/types";
 import {createComputed, createSignal, lazy} from "solid-js";
+import {MeetingChangeSuccessData} from "./meeting_change_success_data";
 
 const MeetingViewEditForm = lazy(() => import("features/meeting/MeetingViewEditForm"));
 
@@ -11,6 +12,11 @@ interface FormParams {
   readonly meetingId: Api.Id;
   /** Whether to show the meeting initially in view mode (and not in edit mode). Default: true. */
   readonly initialViewMode?: boolean;
+  onDeleted?: (meetingId: string) => void;
+  onEdited?: (meeting: MeetingChangeSuccessData) => void;
+  onCopyCreated?: (meeting: MeetingChangeSuccessData) => void;
+  /** Whether to show toast on success. Default: true. */
+  readonly showToast?: boolean;
 }
 
 export const createMeetingModal = registerGlobalPageElement<FormParams>((args) => {
@@ -31,9 +37,20 @@ export const createMeetingModal = registerGlobalPageElement<FormParams>((args) =
             id={params().meetingId}
             viewMode={viewMode()}
             onViewModeChange={setViewMode}
-            onEdited={args.clearParams}
-            onDeleted={args.clearParams}
+            onEdited={(meeting) => {
+              params().onEdited?.(meeting);
+              args.clearParams();
+            }}
+            onCopyCreated={(meeting) => {
+              params().onCopyCreated?.(meeting);
+              args.clearParams();
+            }}
+            onDeleted={() => {
+              params().onDeleted?.(params().meetingId);
+              args.clearParams();
+            }}
             onCancel={args.clearParams}
+            showToast={params().showToast}
           />
         );
       }}

--- a/resources/js/features/meeting/meeting_time_controller.tsx
+++ b/resources/js/features/meeting/meeting_time_controller.tsx
@@ -27,7 +27,7 @@ interface FormTimeDataType extends Obj {
   };
 }
 
-export function meetingTimeInitialValues(time?: DateTime, durationMinutes?: number) {
+export function meetingTimeInitialValue(time?: DateTime, durationMinutes?: number) {
   const localTime = time?.toLocal().startOf("minute");
   function timeInput(time: DateTime | undefined) {
     return time ? dateTimeToTimeInput(time) : "";

--- a/resources/lang/pl_PL/calendar.yml
+++ b/resources/lang/pl_PL/calendar.yml
@@ -48,3 +48,8 @@ weekday_overrides:
   "pt.": "pt"
   "sob.": "so"
   "niedz.": "nd"
+
+relative_time:
+  in_one_day: "następnego dnia"
+  in_one_week: "tydzień później"
+  in_two_weeks: "dwa tygodnie później"

--- a/resources/lang/pl_PL/routes.yml
+++ b/resources/lang/pl_PL/routes.yml
@@ -11,7 +11,7 @@ admin:
   users: "$t(models.user._name_plural)"
 
 facility:
-  home: "informacje"
+  home: "placówka"
   calendar: "$t(calendar.calendar)"
   meetings_list: "lista spotkań"
   staff: "$t(models.staff._name_plural)"


### PR DESCRIPTION
- Create a copy of a meeting from the meeting details.
- Blink a recently created/edited meeting for a moment, to make it easier to find.
- On the toast with the success message after creating/editing a meeting, display a Show button that goes to the date/time/staff of the meeting, and blinks it.
- All the visible copies of a meeting (in different staff columns) get the hover effect together when hovering any of them.